### PR TITLE
Make tide happy - add owners file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - enxebre
+  - frobware
+  - ingvagabund
+  - paulfantom
+  - spangenberg
+  - trawler
+  - vikaschoudhary16


### PR DESCRIPTION
Without this file prow/some_bot won't add `approved` label, so tide won't merge our PRs.

/assign @enxebre @ingvagabund @spangenberg @trawler @frobware 