### PR TITLE
actuators/machine: Fix "Coud" -> "Could" typo

### DIFF
--- a/cloud/libvirt/actuators/machine/actuator.go
+++ b/cloud/libvirt/actuators/machine/actuator.go
@@ -47,7 +47,7 @@ func (a *Actuator) Create(cluster *clusterv1.Cluster, machine *clusterv1.Machine
 	// TODO: hack to increase IPs. Build proper logic in setNetworkInterfaces method
 	a.cidrOffset++
 	if err := libvirtutils.CreateVolumeAndMachine(machine, a.cidrOffset); err != nil {
-		glog.Errorf("Coud not create libvirt machine: %v", err)
+		glog.Errorf("Could not create libvirt machine: %v", err)
 		return fmt.Errorf("error creating machine %v", err)
 	}
 	return nil


### PR DESCRIPTION
Fix the misspelling from cd386e44 (#14).

I also like to downcase these to conform to [the Go error guidelines][1], although as discussed there that's not required for logs.  But in this commit I've left it for consistency with the package's other logs:

```console
$ sudo crictl logs --tail 5 06c3b913cf5e2
I0923 05:25:10.018081       1 controller.go:123] reconciling machine object worker-f55vm triggers idempotent create.
I0923 05:25:10.022519       1 actuator.go:46] Creating machine "worker-f55vm" for cluster "trking-01e8e".
I0923 05:25:10.032481       1 logs.go:41] [INFO] Created libvirt client
I0923 05:25:10.032512       1 logs.go:41] [DEBUG] Create a libvirt volume with name worker-f55vm for pool default from the base volume /var/lib/libvirt/images/coreos_base
E0923 05:25:10.040398       1 actuator.go:50] Coud not create libvirt machine: error creating volume: Can't retrieve volume /var/lib/libvirt/images/coreos_base
```

[Reported][2] by @mrogers950.

[1]: https://github.com/golang/go/wiki/CodeReviewComments#error-strings
[2]: https://github.com/openshift/installer/issues/308#issue-362783831