### PR TITLE
add actuator binary tests and decouples libvirt utils from machine api

### DIFF
--- a/cloud/libvirt/actuators/machine/utils/ignition.go
+++ b/cloud/libvirt/actuators/machine/utils/ignition.go
@@ -1,0 +1,190 @@
+package libvirt
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	libvirt "github.com/libvirt/libvirt-go"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+func CreateIgntion(pool, name, content string, client *Client) error {
+	log.Printf("[DEBUG] creating ignition file")
+	ignition := newIgnitionDef()
+
+	ignition.Name = name
+	ignition.PoolName = pool
+	ignition.Content = content
+
+	log.Printf("[INFO] ignition: %+v", ignition)
+
+	key, err := ignition.CreateAndUpload(client)
+	log.Printf("[INFO] Ignition ID: %s", key)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type defIgnition struct {
+	Name     string
+	PoolName string
+	Content  string
+}
+
+// Creates a new cloudinit with the defaults
+// the provider uses
+func newIgnitionDef() defIgnition {
+	return defIgnition{}
+}
+
+// Create a ISO file based on the contents of the CloudInit instance and
+// uploads it to the libVirt pool
+// Returns a string holding terraform's internal ID of this resource
+func (ign *defIgnition) CreateAndUpload(client *Client) (string, error) {
+	pool, err := client.libvirt.LookupStoragePoolByName(ign.PoolName)
+	if err != nil {
+		return "", fmt.Errorf("can't find storage pool %q", ign.PoolName)
+	}
+	defer pool.Free()
+
+	//client.poolMutexKV.Lock(ign.PoolName)
+	//defer client.poolMutexKV.Unlock(ign.PoolName)
+
+	// Refresh the pool of the volume so that libvirt knows it is
+	// not longer in use.
+	err = waitForSuccess("Error refreshing pool for volume", func() error {
+		return pool.Refresh(0)
+	})
+	if err != nil {
+		return "", fmt.Errorf("timeout when calling waitForSuccess: %v", err)
+	}
+
+	volumeDef := newDefVolume()
+	volumeDef.Name = ign.Name
+
+	ignFile, err := ign.createFile()
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		// Remove the tmp ignition file
+		if err = os.Remove(ignFile); err != nil {
+			log.Printf("Error while removing tmp Ignition file: %s", err)
+		}
+	}()
+
+	img, err := newImage(ignFile)
+	if err != nil {
+		return "", err
+	}
+
+	size, err := img.Size()
+	if err != nil {
+		return "", err
+	}
+
+	volumeDef.Capacity.Unit = "B"
+	volumeDef.Capacity.Value = size
+	volumeDef.Target.Format.Type = "raw"
+
+	volumeDefXML, err := xml.Marshal(volumeDef)
+	if err != nil {
+		return "", fmt.Errorf("Error serializing libvirt volume: %s", err)
+	}
+
+	// create the volume
+	volume, err := pool.StorageVolCreateXML(string(volumeDefXML), 0)
+	if err != nil {
+		return "", fmt.Errorf("Error creating libvirt volume for Ignition %s: %s", ign.Name, err)
+	}
+	defer volume.Free()
+
+	// upload ignition file
+	err = img.Import(newCopier(client.libvirt, volume, volumeDef.Capacity.Value), volumeDef)
+	if err != nil {
+		return "", fmt.Errorf("Error while uploading ignition file %s: %s", img.String(), err)
+	}
+
+	key, err := volume.GetKey()
+	if err != nil {
+		return "", fmt.Errorf("Error retrieving volume key: %s", err)
+	}
+	log.Printf("[INFO] Ignition ID: %s", key)
+	return key, nil
+}
+
+// Dumps the Ignition object to a temporary ignition file
+func (ign *defIgnition) createFile() (string, error) {
+	log.Print("Creating Ignition temporary file")
+	tempFile, err := ioutil.TempFile("", ign.Name)
+	if err != nil {
+		return "", fmt.Errorf("Cannot create tmp file for Ignition: %s",
+			err)
+	}
+	defer tempFile.Close()
+
+	var file bool
+	file = true
+	if _, err := os.Stat(ign.Content); err != nil {
+		var js map[string]interface{}
+		if errConf := json.Unmarshal([]byte(ign.Content), &js); errConf != nil {
+			return "", fmt.Errorf("coreos_ignition 'content' is neither a file "+
+				"nor a valid json object %s", ign.Content)
+		}
+		file = false
+	}
+
+	if !file {
+		if _, err := tempFile.WriteString(ign.Content); err != nil {
+			return "", fmt.Errorf("Cannot write Ignition object to temporary " +
+				"ignition file")
+		}
+	} else if file {
+		ignFile, err := os.Open(ign.Content)
+		if err != nil {
+			return "", fmt.Errorf("Error opening supplied Ignition file %s", ign.Content)
+		}
+		defer ignFile.Close()
+		_, err = io.Copy(tempFile, ignFile)
+		if err != nil {
+			return "", fmt.Errorf("Error copying supplied Igition file to temporary file: %s", ign.Content)
+		}
+	}
+	return tempFile.Name(), nil
+}
+
+func newCopier(virConn *libvirt.Connect, volume *libvirt.StorageVol, size uint64) func(src io.Reader) error {
+	copier := func(src io.Reader) error {
+		var bytesCopied int64
+
+		stream, err := virConn.NewStream(0)
+		if err != nil {
+			return err
+		}
+
+		defer func() {
+			if uint64(bytesCopied) != size {
+				stream.Abort()
+			} else {
+				stream.Finish()
+			}
+			stream.Free()
+		}()
+
+		volume.Upload(stream, 0, size, 0)
+
+		sio := NewStreamIO(*stream)
+
+		bytesCopied, err = io.Copy(sio, src)
+		if err != nil {
+			return err
+		}
+		log.Printf("%d bytes uploaded\n", bytesCopied)
+		return nil
+	}
+	return copier
+}

--- a/cloud/libvirt/actuators/machine/utils/image.go
+++ b/cloud/libvirt/actuators/machine/utils/image.go
@@ -1,0 +1,126 @@
+package libvirt
+
+import (
+	"fmt"
+	"github.com/libvirt/libvirt-go-xml"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type image interface {
+	Size() (uint64, error)
+	Import(func(io.Reader) error, libvirtxml.StorageVolume) error
+	String() string
+}
+
+type httpImage struct {
+	url *url.URL
+}
+
+func (i *httpImage) String() string {
+	return i.url.String()
+}
+
+func (i *httpImage) Size() (uint64, error) {
+	response, err := http.Head(i.url.String())
+	if err != nil {
+		return 0, err
+	}
+	if response.StatusCode != 200 {
+		return 0,
+			fmt.Errorf(
+				"Error accessing remote resource: %s - %s",
+				i.url.String(),
+				response.Status)
+	}
+
+	length, err := strconv.Atoi(response.Header.Get("Content-Length"))
+	if err != nil {
+		err = fmt.Errorf(
+			"Error while getting Content-Length of %q: %v - got %s",
+			i.url.String(),
+			err,
+			response.Header.Get("Content-Length"))
+		return 0, err
+	}
+	return uint64(length), nil
+}
+
+func (i *httpImage) Import(copier func(io.Reader) error, vol libvirtxml.StorageVolume) error {
+	client := &http.Client{}
+	req, _ := http.NewRequest("GET", i.url.String(), nil)
+
+	if vol.Target.Timestamps != nil && vol.Target.Timestamps.Mtime != "" {
+		req.Header.Set("If-Modified-Since", timeFromEpoch(vol.Target.Timestamps.Mtime).UTC().Format(http.TimeFormat))
+	}
+	response, err := client.Do(req)
+
+	if err != nil {
+		return fmt.Errorf("Error while downloading %s: %s", i.url.String(), err)
+	}
+
+	defer response.Body.Close()
+	if response.StatusCode == http.StatusNotModified {
+		return nil
+	}
+
+	return copier(response.Body)
+}
+
+type localImage struct {
+	path string
+}
+
+func newImage(source string) (image, error) {
+	url, err := url.Parse(source)
+	if err != nil {
+		return nil, fmt.Errorf("can't parse source %q as url: %v", source, err)
+	}
+
+	if strings.HasPrefix(url.Scheme, "http") {
+		return &httpImage{url: url}, nil
+	} else if url.Scheme == "file" || url.Scheme == "" {
+		return &localImage{path: url.Path}, nil
+	} else {
+		return nil, fmt.Errorf("don't know how to read from %q: %s", url.String(), err)
+	}
+}
+
+func (i *localImage) String() string {
+	return i.path
+}
+
+func (i *localImage) Size() (uint64, error) {
+	fi, err := os.Stat(i.path)
+	if err != nil {
+		return 0, err
+	}
+	return uint64(fi.Size()), nil
+}
+
+func (i *localImage) Import(copier func(io.Reader) error, vol libvirtxml.StorageVolume) error {
+	file, err := os.Open(i.path)
+	defer file.Close()
+	if err != nil {
+		return fmt.Errorf("Error while opening %s: %s", i.path, err)
+	}
+
+	fi, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	// we can skip the upload if the modification times are the same
+	if vol.Target.Timestamps != nil && vol.Target.Timestamps.Mtime != "" {
+		if fi.ModTime() == timeFromEpoch(vol.Target.Timestamps.Mtime) {
+			log.Printf("Modification time is the same: skipping image copy")
+			return nil
+		}
+	}
+
+	return copier(file)
+}

--- a/cloud/libvirt/actuators/machine/utils/network.go
+++ b/cloud/libvirt/actuators/machine/utils/network.go
@@ -1,0 +1,323 @@
+package libvirt
+
+import (
+	"encoding/xml"
+	"fmt"
+	libvirt "github.com/libvirt/libvirt-go"
+	"github.com/libvirt/libvirt-go-xml"
+	"log"
+	"math/rand"
+	"net"
+)
+
+const (
+	netModeIsolated = "none"
+	netModeNat      = "nat"
+	netModeRoute    = "route"
+	netModeBridge   = "bridge"
+)
+
+// Network interface used to expose a libvirt.Network
+type Network interface {
+	GetXMLDesc(flags libvirt.NetworkXMLFlags) (string, error)
+}
+
+func newDefNetworkfromLibvirt(network Network) (libvirtxml.Network, error) {
+	networkXMLDesc, err := network.GetXMLDesc(0)
+	if err != nil {
+		return libvirtxml.Network{}, fmt.Errorf("Error retrieving libvirt domain XML description: %s", err)
+	}
+	networkDef := libvirtxml.Network{}
+	err = xml.Unmarshal([]byte(networkXMLDesc), &networkDef)
+	if err != nil {
+		return libvirtxml.Network{}, fmt.Errorf("Error reading libvirt network XML description: %s", err)
+	}
+	return networkDef, nil
+}
+
+// HasDHCP checks if the network has a DHCP server managed by libvirt
+func HasDHCP(net libvirtxml.Network) bool {
+	if net.Forward != nil {
+		if net.Forward.Mode == "nat" || net.Forward.Mode == "route" || net.Forward.Mode == "" {
+			return true
+		}
+	}
+	return false
+}
+
+// Tries to update first, if that fails, it will add it
+func updateOrAddHost(n *libvirt.Network, ip, mac, name string) error {
+	err := updateHost(n, ip, mac, name)
+	if virErr, ok := err.(libvirt.Error); ok && virErr.Code == libvirt.ERR_OPERATION_INVALID && virErr.Domain == libvirt.FROM_NETWORK {
+		return addHost(n, ip, mac, name)
+	}
+	return err
+}
+
+// Adds a new static host to the network
+func addHost(n *libvirt.Network, ip, mac, name string) error {
+	xmlDesc, err := getHostXMLDesc(ip, mac, name)
+	if err != nil {
+		return fmt.Errorf("error getting host xml desc: %v", err)
+	}
+	log.Printf("Adding host with XML:\n%s", xmlDesc)
+	return n.Update(libvirt.NETWORK_UPDATE_COMMAND_ADD_LAST, libvirt.NETWORK_SECTION_IP_DHCP_HOST, -1, xmlDesc, libvirt.NETWORK_UPDATE_AFFECT_CURRENT)
+}
+
+func getHostXMLDesc(ip, mac, name string) (string, error) {
+	networkDHCPHost := libvirtxml.NetworkDHCPHost{
+		IP:   ip,
+		MAC:  mac,
+		Name: name,
+	}
+	tmp := struct {
+		XMLName xml.Name `xml:"host"`
+		libvirtxml.NetworkDHCPHost
+	}{xml.Name{}, networkDHCPHost}
+	xml, err := xmlMarshallIndented(tmp)
+	if err != nil {
+		return "", fmt.Errorf("could not marshall: %v", err)
+	}
+	return xml, nil
+}
+
+// Update a static host from the network
+func updateHost(n *libvirt.Network, ip, mac, name string) error {
+	xmlDesc, err := getHostXMLDesc(ip, mac, name)
+	if err != nil {
+		return fmt.Errorf("error getting host xml desc: %v", err)
+	}
+	log.Printf("Updating host with XML:\n%s", xmlDesc)
+	return n.Update(libvirt.NETWORK_UPDATE_COMMAND_MODIFY, libvirt.NETWORK_SECTION_IP_DHCP_HOST, -1, xmlDesc, libvirt.NETWORK_UPDATE_AFFECT_CURRENT)
+}
+
+// randomMACAddress returns a randomized MAC address
+func randomMACAddress() (string, error) {
+	buf := make([]byte, 6)
+	_, err := rand.Read(buf)
+	if err != nil {
+		return "", err
+	}
+
+	// set local bit and unicast
+	buf[0] = (buf[0] | 2) & 0xfe
+	// Set the local bit
+	buf[0] |= 2
+
+	// avoid libvirt-reserved addresses
+	if buf[0] == 0xfe {
+		buf[0] = 0xee
+	}
+
+	return fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x",
+		buf[0], buf[1], buf[2], buf[3], buf[4], buf[5]), nil
+}
+
+// Creates a network definition from a XML
+func newDefNetworkFromXML(s string) (libvirtxml.Network, error) {
+	var networkDef libvirtxml.Network
+	err := xml.Unmarshal([]byte(s), &networkDef)
+	if err != nil {
+		return libvirtxml.Network{}, err
+	}
+	return networkDef, nil
+}
+
+// Creates a network definition with the defaults the provider uses
+func newNetworkDef() (libvirtxml.Network, error) {
+	const defNetworkXML = `
+		<network>
+		  <name>default</name>
+		  <forward mode='nat'>
+		    <nat>
+		      <port start='1024' end='65535'/>
+		    </nat>
+		  </forward>
+		</network>`
+	if d, err := newDefNetworkFromXML(defNetworkXML); err != nil {
+		return libvirtxml.Network{}, fmt.Errorf("unexpected error while parsing default network definition: %v", err)
+	} else {
+		return d, nil
+	}
+}
+
+func CreateNetwork(name, domain, bridge, mode string, addresses []string, autostart bool, client *Client) error {
+	// see https://libvirt.org/formatnetwork.html
+	virConn := client.libvirt
+
+	networkDef, err := newNetworkDef()
+	if err != nil {
+		return fmt.Errorf("error creating network definition %v", err)
+	}
+	networkDef.Name = name
+	networkDef.Domain = &libvirtxml.NetworkDomain{
+		Name: domain,
+	}
+
+	networkDef.Bridge = &libvirtxml.NetworkBridge{
+		Name: bridge,
+		STP:  "on",
+	}
+
+	// check the network mode
+	networkDef.Forward = &libvirtxml.NetworkForward{
+		Mode: mode,
+	}
+	if networkDef.Forward.Mode == netModeIsolated || networkDef.Forward.Mode == netModeNat || networkDef.Forward.Mode == netModeRoute {
+
+		if networkDef.Forward.Mode == netModeIsolated {
+			// there is no forwarding when using an isolated network
+			networkDef.Forward = nil
+		} else if networkDef.Forward.Mode == netModeRoute {
+			// there is no NAT when using a routed network
+			networkDef.Forward.NAT = nil
+		}
+
+		// some network modes require a DHCP/DNS server
+		// set the addresses for DHCP
+		if len(addresses) > 0 {
+			ipsPtrsLst := []libvirtxml.NetworkIP{}
+			for _, address := range addresses {
+				_, ipNet, err := net.ParseCIDR(address)
+				if err != nil {
+					return fmt.Errorf("error parsing addresses definition %q: %v", address, err)
+				}
+				ones, bits := ipNet.Mask.Size()
+				family := "ipv4"
+				if bits == (net.IPv6len * 8) {
+					family = "ipv6"
+				}
+				ipsRange := 2 ^ bits - 2 ^ ones
+				if ipsRange < 4 {
+					return fmt.Errorf("Netmask seems to be too strict: only %d IPs available (%s)", ipsRange-3, family)
+				}
+
+				// we should calculate the range served by DHCP. For example, for
+				// 192.168.121.0/24 we will serve 192.168.121.2 - 192.168.121.254
+				start, end := networkRange(ipNet)
+
+				// skip the .0, (for the network),
+				start[len(start)-1]++
+
+				// assign the .1 to the host interface
+				dni := libvirtxml.NetworkIP{
+					Address: start.String(),
+					Prefix:  uint(ones),
+					Family:  family,
+				}
+
+				start[len(start)-1]++ // then skip the .1
+				end[len(end)-1]--     // and skip the .255 (for broadcast)
+
+				dni.DHCP = &libvirtxml.NetworkDHCP{
+					Ranges: []libvirtxml.NetworkDHCPRange{
+						{
+							Start: start.String(),
+							End:   end.String(),
+						},
+					},
+				}
+				ipsPtrsLst = append(ipsPtrsLst, dni)
+			}
+			networkDef.IPs = ipsPtrsLst
+		}
+
+	} else if networkDef.Forward.Mode == netModeBridge {
+		if bridge == "" {
+			return fmt.Errorf("'bridge' must be provided when using the bridged network mode")
+		}
+		// Bridges cannot forward
+		networkDef.Forward = nil
+	} else {
+		return fmt.Errorf("unsupported network mode '%s'", networkDef.Forward.Mode)
+	}
+
+	// once we have the network defined, connect to libvirt and create it from the XML serialization
+	connectURI, err := virConn.GetURI()
+	if err != nil {
+		return fmt.Errorf("Error retrieving libvirt connection URI: %s", err)
+	}
+	log.Printf("[INFO] Creating libvirt network at %s", connectURI)
+
+	data, err := xmlMarshallIndented(networkDef)
+	if err != nil {
+		return fmt.Errorf("Error serializing libvirt network: %s", err)
+	}
+
+	log.Printf("[DEBUG] Creating libvirt network at %s: %s", connectURI, data)
+	network, err := virConn.NetworkDefineXML(data)
+	if err != nil {
+		return fmt.Errorf("Error defining libvirt network: %s - %s", err, data)
+	}
+	err = network.Create()
+	if err != nil {
+		return fmt.Errorf("Error crearing libvirt network: %s", err)
+	}
+	defer network.Free()
+
+	id, err := network.GetUUIDString()
+	if err != nil {
+		return fmt.Errorf("Error retrieving libvirt network id: %s", err)
+	}
+	log.Printf("[INFO] Created network %s [%s]", networkDef.Name, id)
+
+	if autostart {
+		err = network.SetAutostart(autostart)
+		if err != nil {
+			return fmt.Errorf("Error setting autostart for network: %s", err)
+		}
+	}
+	return nil
+}
+
+// networkRange calculates the first and last IP addresses in an IPNet
+func networkRange(network *net.IPNet) (net.IP, net.IP) {
+	netIP := network.IP.To4()
+	lastIP := net.IPv4(0, 0, 0, 0).To4()
+	if netIP == nil {
+		netIP = network.IP.To16()
+		lastIP = net.IPv6zero.To16()
+	}
+	firstIP := netIP.Mask(network.Mask)
+	for i := 0; i < len(lastIP); i++ {
+		lastIP[i] = netIP[i] | ^network.Mask[i]
+	}
+	return firstIP, lastIP
+}
+
+func DeleteNetwork(name string, client *Client) error {
+	virConn := client.libvirt
+
+	network, err := virConn.LookupNetworkByName(name)
+	if err != nil {
+		return fmt.Errorf("When destroying libvirt network: error retrieving %s", err)
+	}
+	defer network.Free()
+
+	active, err := network.IsActive()
+	if err != nil {
+		return fmt.Errorf("Couldn't determine if network is active: %s", err)
+	}
+	if !active {
+		// we have to restart an inactive network, otherwise it won't be
+		// possible to remove it.
+		if err := network.Create(); err != nil {
+			return fmt.Errorf("Cannot restart an inactive network %s", err)
+		}
+	}
+
+	if err := network.Destroy(); err != nil {
+		return fmt.Errorf("When destroying libvirt network: %s", err)
+	}
+
+	if err := network.Undefine(); err != nil {
+		return fmt.Errorf("Couldn't undefine libvirt network: %s", err)
+	}
+
+	if err != nil {
+		return fmt.Errorf("Error waiting for network to reach NOT-EXISTS state: %s", err)
+	}
+
+	log.Printf("deleted network %s", name)
+	return nil
+}

--- a/cloud/libvirt/actuators/machine/utils/stream.go
+++ b/cloud/libvirt/actuators/machine/utils/stream.go
@@ -1,0 +1,26 @@
+package libvirt
+
+import libvirt "github.com/libvirt/libvirt-go"
+
+// StreamIO libvirt struct
+type StreamIO struct {
+	Stream libvirt.Stream
+}
+
+// NewStreamIO returns libvirt StreamIO
+func NewStreamIO(s libvirt.Stream) *StreamIO {
+	return &StreamIO{Stream: s}
+}
+
+func (sio *StreamIO) Read(p []byte) (int, error) {
+	return sio.Stream.Recv(p)
+}
+
+func (sio *StreamIO) Write(p []byte) (int, error) {
+	return sio.Stream.Send(p)
+}
+
+// Close closes the stream
+func (sio *StreamIO) Close() error {
+	return sio.Stream.Finish()
+}

--- a/cmd/libvirt-actuator/utils/utils.go
+++ b/cmd/libvirt-actuator/utils/utils.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/ghodss/yaml"
+	machineactuator "github.com/openshift/cluster-api-provider-libvirt/cloud/libvirt/actuators/machine"
+	log "github.com/sirupsen/logrus"
+	"io/ioutil"
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/fake"
+)
+
+func ReadClusterResources(clusterLoc, machineLoc string) (*clusterv1.Cluster, *clusterv1.Machine, error) {
+	machine := &clusterv1.Machine{}
+	{
+		bytes, err := ioutil.ReadFile(machineLoc)
+		if err != nil {
+			return nil, nil, fmt.Errorf("machine manifest %q: %v", machineLoc, err)
+		}
+
+		if err = yaml.Unmarshal(bytes, &machine); err != nil {
+			return nil, nil, fmt.Errorf("machine manifest %q: %v", machineLoc, err)
+		}
+	}
+
+	cluster := &clusterv1.Cluster{}
+	{
+		bytes, err := ioutil.ReadFile(clusterLoc)
+		if err != nil {
+			return nil, nil, fmt.Errorf("cluster manifest %q: %v", clusterLoc, err)
+		}
+
+		if err = yaml.Unmarshal(bytes, &cluster); err != nil {
+			return nil, nil, fmt.Errorf("cluster manifest %q: %v", clusterLoc, err)
+		}
+	}
+
+	return cluster, machine, nil
+}
+
+func CreateActuator(machine *clusterv1.Machine, logger *log.Entry) *machineactuator.Actuator {
+	fakeClient := fake.NewSimpleClientset(machine)
+	params := machineactuator.ActuatorParams{
+		ClusterClient: fakeClient,
+	}
+	actuator, _ := machineactuator.NewActuator(params)
+	return actuator
+}

--- a/examples/machine-with-full-paths.yaml
+++ b/examples/machine-with-full-paths.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: Machine
+metadata:
+  name: worker-example
+  namespace: test
+  labels:
+    sigs.k8s.io/cluster-api-cluster: cluster-name
+    sigs.k8s.io/cluster-api-machine-role: infra
+    sigs.k8s.io/cluster-api-machine-type: worker
+spec:
+  providerConfig:
+    value:
+      apiVersion: libvirtproviderconfig/v1alpha1
+      kind: LibvirtMachineProviderConfig
+      domainMemory: 4086
+      domainVcpu: 2
+      ignKey: /var/lib/libvirt/images/worker.ign
+      volume:
+        poolName: default
+        baseVolumeID: /var/lib/libvirt/images/baseVolume
+      networkInterfaceName: actuatorTestNetwork
+      networkInterfaceAddress: 192.168.124.0/24
+      autostart: false
+      uri: qemu+tcp://127.0.0.1/system
+  versions:
+    kubelet: ""
+    controlPlane: ""

--- a/tests/actuator/README.md
+++ b/tests/actuator/README.md
@@ -1,0 +1,11 @@
+# Test for actuator in isolation (no cluster api)
+
+## Build
+```
+CGO_ENABLED=1 go install github.com/openshift/cluster-api-provider-libvirt/tests/actuator
+```
+
+## Run
+```
+$GOPATH/go/bin/actuator -m examples/
+```

--- a/tests/actuator/test.go
+++ b/tests/actuator/test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"fmt"
+	libvirtutils "github.com/openshift/cluster-api-provider-libvirt/cloud/libvirt/actuators/machine/utils"
+	actuator "github.com/openshift/cluster-api-provider-libvirt/cmd/libvirt-actuator/utils"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+)
+
+// Test cases
+
+const defaultLogLevel = "debug"
+const defaultlibvirtdURI = "qemu:///system"
+
+var rootCmd = &cobra.Command{
+	Use:   "actuator-test",
+	Short: "Test the actuator without going through the cluster API",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logLevel := cmd.Flag("log-level").Value.String()
+		libvirtdURI := cmd.Flag("libvirtd-uri").Value.String()
+		manifestsDir := cmd.Flag("manifests-dir").Value.String()
+		log.SetOutput(os.Stdout)
+		if lvl, err := log.ParseLevel(logLevel); err != nil {
+			log.Panic(err)
+		} else {
+			log.SetLevel(lvl)
+		}
+
+		testCases := []struct {
+			machineFile         string
+			expectedReachableIP string
+		}{
+			{
+				machineFile:         "machine-with-full-paths.yaml",
+				expectedReachableIP: "192.168.124.51", // currently the actuator starts with an offset of 50
+			},
+		}
+		//build libvirtd client
+		client, err := libvirtutils.BuildClient(libvirtdURI)
+		if err != nil {
+			return fmt.Errorf("Failed to build libvirt client: %s", err)
+		}
+
+		if err := createActuatorInfraAssumtions(client); err != nil {
+			log.Errorf("failed creating actuator infra assumtions %v", err)
+			//return err
+		}
+		defer destroyActuatorInfraAssumtions(client)
+
+		for _, test := range testCases {
+			// create machine to manually test
+			cluster, machine, err := actuator.ReadClusterResources(
+				path.Join(manifestsDir, "cluster.yaml"),
+				path.Join(manifestsDir, test.machineFile),
+			)
+			name := machine.Name
+			if err != nil {
+				log.Errorf("failed reading cluster resources %v", err)
+				return err
+			}
+
+			actuator := actuator.CreateActuator(machine, log.WithField("example", "create-machine"))
+			err = actuator.Create(cluster, machine)
+			if err != nil {
+				return err
+			}
+			log.Info("machine creation was successful!")
+
+			// validations
+			// the actuator reports the machine exists
+			exists, err := actuator.Exists(cluster, machine)
+			if err != nil {
+				log.Errorf("error checking if machine %s exists", name)
+				return err
+			}
+			if exists != true {
+				log.Errorf("machine %s expected but not found", name)
+				return err
+			}
+			log.Infof("verified the actuator reporrs the machine %s exists", name)
+
+			// there's a volume with the domain name
+			exists, err = libvirtutils.DomainExists(name, client)
+			if err != nil {
+				log.Errorf("error checking if domain %s exists", name)
+				return err
+			}
+			if exists != true {
+				log.Errorf("domain %s expected but not found", name)
+				return err
+			}
+			log.Infof("verified that domain %s exists", name)
+
+			// verify is reachable, TODO(alberto) find a better way to do this
+			out, _ := exec.Command("ping", test.expectedReachableIP, "-c 5", "-i 5").Output()
+			if !strings.Contains(string(out), "bytes from") {
+				log.Errorf("domain %s not reachable for ip %s, %s", name, test.expectedReachableIP, string(out))
+				return err
+			}
+			log.Infof("verified domain %s is reachable for ip %s", name, test.expectedReachableIP)
+			// TODO(alberto) ssh and verify ignition config
+
+			err = actuator.Delete(cluster, machine)
+			if err != nil {
+				return err
+			}
+			log.Info("machine deletion was successful!")
+		}
+		return nil
+
+	},
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringP("log-level", "l", defaultLogLevel, "Log level (debug,info,warn,error,fatal)")
+	rootCmd.PersistentFlags().StringP("libvirtd-uri", "u", defaultlibvirtdURI, "Libvirtd url (qemu+tcp://ip/system)")
+	rootCmd.PersistentFlags().StringP("manifests-dir", "m", ".", "./examples")
+}
+
+func createActuatorInfraAssumtions(client *libvirtutils.Client) error {
+	// TODO(alberto) Create poolName: default
+
+	// Create base volume from image (libvirt_base_volume)
+	if err := libvirtutils.CreateVolume("baseVolume", "default", "", "file:///root/coreos_production_qemu_image.img", "qcow2", client); err != nil {
+		log.Errorf("failed creating base volume %v", err)
+		return err
+	}
+
+	// Create ign volume
+	content := `{"ignition":{"version":"2.2.0"},"networkd":{},"passwd":{"users":[{"name":"core","passwordHash": "$6$Jez3bVF7jG$ncmvBeJiYbzFKZSQKzTwg9gJ2qoF4N.JYyt8iv4qCThCdJmOtxnZz3l1W3btoh9.bXE8DcdXr6iXuV7ES4kww0"}]},"storage":{},"systemd":{}}`
+	if err := libvirtutils.CreateIgntion("default", "worker.ign", content, client); err != nil {
+		log.Errorf("failed creating ignition %v", err)
+		return err
+	}
+
+	// Create networkInterfaceName
+	if err := libvirtutils.CreateNetwork("actuatorTestNetwork", "tt.test", "tt0", "nat", []string{"192.168.124.0/24"}, false, client); err != nil {
+		log.Errorf("failed creating network %v", err)
+		return err
+	}
+	return nil
+}
+
+func destroyActuatorInfraAssumtions(client *libvirtutils.Client) {
+	// Delete base volume
+	if err := libvirtutils.DeleteVolume("baseVolume", client); err != nil {
+		log.Errorf("failed deleting base volume %v", err)
+	}
+
+	// Delete ign volume
+	if err := libvirtutils.DeleteVolume("worker.ign", client); err != nil {
+		log.Errorf("failed creating ignition %v", err)
+	}
+
+	// Delete networkInterfaceName
+	if err := libvirtutils.DeleteNetwork("actuatorTestNetwork", client); err != nil {
+		log.Errorf("failed creating network %v", err)
+	}
+}
+
+func main() {
+	err := rootCmd.Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error occurred: %v\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
- Refactor `cloud/libvir/actuator/machines/utils` and decouples it from the cluster api, so in a follow up we should move `utils` up to `pkg/`
- Add automation on `tests/actuator` for running tests for the actuator in isolation (no cluster api)
- Increase the DSL based on https://github.com/dmacvicar/terraform-provider-libvirt into the utils library so it can be also used by the tests to generate assumptions via libvirt library, e.g `CreateNetwork` or support to create ignition volumes
This is to start to give some love to this actuator. This tests can be now run on CI on a packet machine.
