### PR TITLE
Initialize rand.Seed to generate random MAC addresses

### DIFF
--- a/cloud/libvirt/actuators/machine/utils/domain.go
+++ b/cloud/libvirt/actuators/machine/utils/domain.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	"math/rand"
 
@@ -25,6 +26,10 @@ const (
 
 // LibVirtConIsNil contains a nil connection error message
 var LibVirtConIsNil = "the libvirt connection was nil"
+
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
+}
 
 // Client libvirt
 type Client struct {


### PR DESCRIPTION
Once build, the actuator always generate the same MAC address for all machines.

Thus, the seed needs to be set to a value that produces different random sequence no matter when the MAC address is generated.

Based on https://stackoverflow.com/questions/12321133/golang-random-number-generator-how-to-seed-properly