### PR TITLE
Use faster packet instance

### DIFF
--- a/hack/prebuild/main.tf
+++ b/hack/prebuild/main.tf
@@ -5,7 +5,7 @@ resource "packet_ssh_key" "key" {
 
 resource "packet_device" "libvirt" {
   hostname         = "libvirt-${var.id}"
-  plan             = "baremetal_0"
+  plan             = "baremetal_1"
   facility         = "ewr1"
   operating_system = "centos_7"
   billing_cycle    = "hourly"


### PR DESCRIPTION
use `c1.small.x86` (named `baremetal_1`) instead of `t1.small.x86` (`baremetal_0`)

/assign @ingvagabund 