### PR TITLE
Fix connection leak

### DIFF
--- a/cloud/libvirt/actuators/machine/actuator.go
+++ b/cloud/libvirt/actuators/machine/actuator.go
@@ -184,6 +184,12 @@ func createVolumeAndDomain(machine *clusterv1.Machine, offset int, kubeClient ku
 
 	// Create domain
 	if err = libvirtutils.CreateDomain(name, ignKey, name, name, networkInterfaceName, networkInterfaceAddress, autostart, memory, vcpu, offset, client, machineProviderConfig.CloudInit, kubeClient, machine.Namespace); err != nil {
+		// Clean up the created volume if domain creation fails,
+		// otherwise subsequent runs will fail.
+		if err := libvirtutils.DeleteVolume(name, client); err != nil {
+			glog.Errorf("error cleaning up volume: %v", err)
+		}
+
 		return nil, fmt.Errorf("error creating domain: %v", err)
 	}
 

--- a/cloud/libvirt/actuators/machine/utils/domain.go
+++ b/cloud/libvirt/actuators/machine/utils/domain.go
@@ -40,8 +40,15 @@ type Client struct {
 }
 
 // Close closes the client's libvirt connection.
-func (c *Client) Close() (int, error) {
-	return c.connection.Close()
+func (c *Client) Close() error {
+	log.Printf("[DEBUG] Closing libvirt connection: %p", c.connection)
+
+	_, err := c.connection.Close()
+	if err != nil {
+		log.Printf("Error closing libvirt connection: %v", err)
+	}
+
+	return err
 }
 
 type pendingMapping struct {
@@ -416,7 +423,8 @@ func BuildClient(URI string) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Println("[INFO] Created libvirt client")
+
+	log.Printf("[DEBUG] Created libvirt connection: %p", libvirtClient)
 
 	client := &Client{
 		connection: libvirtClient,


### PR DESCRIPTION
Two quick fixes:

1) Create libvirt client connections in the top-level Create / Update / etc. methods and ensure they are closed. This should fix the leak.

2) Clean up volumes if domain creation fails. Otherwise, subsequent attempts to create the volume and domain will fail because the volume already exists.