### PR TITLE
Makefile: add Go debug support to build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DBG         ?= 0
 VERSION     ?= $(shell git describe --always --abbrev=7)
 MUTABLE_TAG ?= latest
 IMAGE        = origin-libvirt-machine-controllers
+
+ifeq ($(DBG),1)
+GOGCFLAGS ?= -gcflags=all="-N -l"
+endif
 
 .PHONY: all
 all: build images check
@@ -43,7 +48,7 @@ bin:
 
 .PHONY: build
 build: | bin ## build binary
-	$(DOCKER_CMD) go build -o bin/libvirt-actuator github.com/openshift/cluster-api-provider-libvirt/cmd/libvirt-actuator
+	$(DOCKER_CMD) go build $(GOGCFLAGS) -o bin/libvirt-actuator github.com/openshift/cluster-api-provider-libvirt/cmd/libvirt-actuator
 
 .PHONY: images
 images: ## Create images


### PR DESCRIPTION
Invoking:

    $ make build DBG=1

will build bin/libvirt-actuator with Go debug support.

Setting DBG=1 will add GOGCFLAGS to the bin/libvirt-actuator build.
This changes the build rule to now include $(GOGCFLAGS):

    $ go build $(GOGCFLAGS) ...

The default value for GOGCFLAGS is -gcflags=all="-N -l", assuming
GOGCFLAGS it not already set in your environment. "all" specifies that
the flags should be applied to all packages (and may rebuild existing
up to date packages); "-N" disables compiler optimisations and "-l"
prevents inlining.

So, to override the defaults:

    $ make build DBG=1 GOGCFLAGS='-gcflags="-N -l"'