### PR TITLE
Fix minikube version to 0.28.0

### DIFF
--- a/hack/prebuild/init.sh
+++ b/hack/prebuild/init.sh
@@ -61,7 +61,7 @@ yum -y install kubectl
 
 # Install minikube
 # Install 0.28.0 instead of the latest due to https://github.com/kubernetes/minikube/issues/3076
-curl -Lo /tmp/minikube https://storage.googleapis.com/minikube/releases/v0.28.2/minikube-linux-amd64
+curl -Lo /tmp/minikube https://storage.googleapis.com/minikube/releases/v0.28.0/minikube-linux-amd64
 chmod +x /tmp/minikube
 cp /tmp/minikube /usr/local/bin/
 


### PR DESCRIPTION
Otherwise:
```
ERROR: logging before flag.Parse: E1015 15:48:30.765130       1 errors.go:90] Post https://localhost:8443/apis/authorization.k8s.io/v1beta1/subjectaccessreviews: dial tcp 127.0.0.1:8443: connect: connection refused
ERROR: logging before flag.Parse: E1015 15:48:33.415807       1 webhook.go:192] Failed to make webhook authorizer request: Post https://localhost:8443/apis/authorization.k8s.io/v1beta1/subjectaccessreviews: dial tcp 127.0.0.1:8443: connect: connection refused
```