### PR TITLE
Fix machine delete

### DIFF
--- a/pkg/cloud/libvirt/actuators/machine/actuator.go
+++ b/pkg/cloud/libvirt/actuators/machine/actuator.go
@@ -121,8 +121,15 @@ func (a *Actuator) Delete(cluster *clusterv1.Cluster, machine *clusterv1.Machine
 	}
 
 	defer client.Close()
-
-	return deleteVolumeAndDomain(machine, client)
+	exists, err := libvirtutils.DomainExists(machine.Name, client)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return deleteVolumeAndDomain(machine, client)
+	}
+	glog.Infof("Domain %s does not exist. Skipping deletion...", machine.Name)
+	return nil
 }
 
 // Update updates a machine and is invoked by the Machine Controller


### PR DESCRIPTION
Currently if actuator fails to create a machine and user wants to delete the machine object, kubectl hangs forever. This is because in the reconcile function, error is thrown because of failing to find machine. Kubectl hangs because of the finalizer.

This PR adds logic to first verify if machine exists at the actuator before executing Delete at actuator.

Fixes: https://jira.coreos.com/browse/CLOUD-225