### PR TITLE
add tags to instances for easier cleanup

### DIFF
--- a/hack/packet-provision.sh
+++ b/hack/packet-provision.sh
@@ -17,6 +17,7 @@ if [ "$TF_VAR_packet_project_id" == "" ]; then
 fi
 
 export TF_VAR_id=${ID:-$(uuidgen | cut -c1-8)}
+export TF_VAR_tag=${NODE_NAME:-usermachine}
 
 pushd $script_dir/prebuild
 

--- a/hack/packet-provision.sh
+++ b/hack/packet-provision.sh
@@ -17,7 +17,7 @@ if [ "$TF_VAR_packet_project_id" == "" ]; then
 fi
 
 export TF_VAR_id=${ID:-$(uuidgen | cut -c1-8)}
-export TF_VAR_tag=${NODE_NAME:-usermachine}
+export TF_VAR_tag=${NODE_NAME:-$(whoami)}
 
 pushd $script_dir/prebuild
 

--- a/hack/prebuild/main.tf
+++ b/hack/prebuild/main.tf
@@ -10,6 +10,7 @@ resource "packet_device" "libvirt" {
   operating_system = "centos_7"
   billing_cycle    = "hourly"
   project_id       = "${var.packet_project_id}"
+  tags             = "${var.tag}"
   user_data        = "#cloud-config\n#image_repo=https://github.com/paulfantom/packet-image.git\n#image_tag=3a3f1eb378f660b335a68b79f3af303380462652\nssh_pwauth: True"
 
   provisioner "remote-exec" {

--- a/hack/prebuild/main.tf
+++ b/hack/prebuild/main.tf
@@ -10,7 +10,7 @@ resource "packet_device" "libvirt" {
   operating_system = "centos_7"
   billing_cycle    = "hourly"
   project_id       = "${var.packet_project_id}"
-  tags             = "${var.tag}"
+  tags             = "${list("${var.tag}")}"
   user_data        = "#cloud-config\n#image_repo=https://github.com/paulfantom/packet-image.git\n#image_tag=3a3f1eb378f660b335a68b79f3af303380462652\nssh_pwauth: True"
 
   provisioner "remote-exec" {

--- a/hack/prebuild/variables.tf
+++ b/hack/prebuild/variables.tf
@@ -12,3 +12,8 @@ variable "packet_project_id" {
   type    = "string"
   default = ""
 }
+
+variable "tag" {
+  type    = "string"
+  default = "usermachine"
+}


### PR DESCRIPTION
This adds automatic packet.net instance tagging, just in case we will leak resources.

It uses jenkins node name as tag if run on jenkins and `usermachine` otherwise.

/CC @openshift/sig-cloud 