### PR TITLE
Keep the log-level option temporarily

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -18,6 +18,18 @@ import (
 	"github.com/golang/glog"
 )
 
+var (
+	logLevel string
+)
+
+const (
+	defaultLogLevel = "info"
+)
+
+func init() {
+	flag.CommandLine.StringVar(&logLevel, "log-level", defaultLogLevel, "Log level (debug,info,warn,error,fatal)")
+}
+
 func main() {
 	// the following line exists to make glog happy, for more information, see: https://github.com/kubernetes/kubernetes/issues/17162
 	//flag.CommandLine.Parse([]string{})


### PR DESCRIPTION
Keep the `-log-level` option until it's completely removed from the machine-api-operator.

The mao still renders the controller manifest with the `--log-level` flag.

Related: https://github.com/openshift/cluster-api-provider-libvirt/pull/79

Fixes https://github.com/openshift/machine-api-operator/issues/107