### PR TITLE
Makefile: build machines.test e2e binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,10 @@ test: # Run unit test
 integration: deps-cgo ## Run integration test
 	$(DOCKER_CMD) go test -v sigs.k8s.io/cluster-api-provider-libvirt/test/integration
 
+.PHONY: build-e2e
+build-e2e:
+	$(DOCKER_CMD) go test -c -o bin/machines.test github.com/openshift/cluster-api-provider-libvirt/test/machines
+
 .PHONY: e2e
 e2e: e2e-provision ## Run end-to-end test
 	# TODO @ingvagabund @spangenberg add e2e test command here


### PR DESCRIPTION
We need to build the `machines.test` with the same libvirt version as the one installed inside the libvirt instance. Otherwise, the `machines.test` can be built with higher version of `/lib64/libvirt.so.0` that is available inside the instance. In which case the `machines.test` fails with:

```
./machines.test: /lib64/libvirt.so.0: version `LIBVIRT_4.1.0' not found (required by ./machines.test)
./machines.test: /lib64/libvirt.so.0: version `LIBVIRT_4.4.0' not found (required by ./machines.test)
./machines.test: /lib64/libvirt.so.0: version `LIBVIRT_4.5.0' not found (required by ./machines.test)
```