### PR TITLE
Allow to specify an ignition configuration through user secret

### DIFF
--- a/examples/ignition-userdata.yml
+++ b/examples/ignition-userdata.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: libvirt-actuator-ignition-secret
+  namespace: test
+type: Opaque
+data:
+  userData: |
+    ewogICJpZ25pdGlvbiI6IHsgInZlcnNpb24iOiAiMi4yLjAiIH0sCiAgInN5c3RlbWQiOiB7CiAg
+    ICAidW5pdHMiOiBbewogICAgICAibmFtZSI6ICJleGFtcGxlLnNlcnZpY2UiLAogICAgICAiZW5h
+    YmxlZCI6IHRydWUsCiAgICAgICJjb250ZW50cyI6ICJbU2VydmljZV1cblR5cGU9b25lc2hvdFxu
+    RXhlY1N0YXJ0PS91c3IvYmluL2VjaG8gSGVsbG8gV29ybGRcblxuW0luc3RhbGxdXG5XYW50ZWRC
+    eT1tdWx0aS11c2VyLnRhcmdldCIKICAgIH1dCiAgfQp9Cg==

--- a/examples/ignition.json
+++ b/examples/ignition.json
@@ -1,0 +1,10 @@
+{
+  "ignition": { "version": "2.2.0" },
+  "systemd": {
+    "units": [{
+      "name": "example.service",
+      "enabled": true,
+      "contents": "[Service]\nType=oneshot\nExecStart=/usr/bin/echo Hello World\n\n[Install]\nWantedBy=multi-user.target"
+    }]
+  }
+}

--- a/examples/machine-with-userdata.yml
+++ b/examples/machine-with-userdata.yml
@@ -1,0 +1,33 @@
+---
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: Machine
+metadata:
+  name: worker-example
+  namespace: test
+  generateName: vs-worker-
+  labels:
+    sigs.k8s.io/cluster-api-cluster: tb-asg-35
+    sigs.k8s.io/cluster-api-machine-role: infra
+    sigs.k8s.io/cluster-api-machine-type: worker
+spec:
+  providerConfig:
+    value:
+      apiVersion: libvirtproviderconfig.k8s.io/v1alpha1
+      kind: LibvirtMachineProviderConfig
+      domainMemory: 2048
+      domainVcpu: 2
+      ignition:
+        userDataSecret: libvirt-actuator-ignition-secret
+      cloudInit:
+        sshAccess: true
+        userDataSecret: libvirt-actuator-user-data-secret
+      volume:
+        poolName: default
+        baseVolumeID: /var/lib/libvirt/images/fedora_base
+      networkInterfaceName: default
+      networkInterfaceAddress: 192.168.122.0/24
+      autostart: false
+      uri: qemu:///system
+  versions:
+    kubelet: ""
+    controlPlane: ""

--- a/pkg/apis/libvirtproviderconfig/v1alpha1/libvirtmachineproviderconfig_types.go
+++ b/pkg/apis/libvirtproviderconfig/v1alpha1/libvirtmachineproviderconfig_types.go
@@ -14,6 +14,7 @@ type LibvirtMachineProviderConfig struct {
 	DomainMemory             int        `json:"domainMemory"`
 	DomainVcpu               int        `json:"domainVcpu"`
 	IgnKey                   string     `json:"ignKey"`
+	Ignition                 *Ignition  `json:"ignition"`
 	CloudInit                *CloudInit `json:"cloudInit"`
 	Volume                   *Volume    `json:"volume"`
 	NetworkInterfaceName     string     `json:"networkInterfaceName"`
@@ -24,8 +25,13 @@ type LibvirtMachineProviderConfig struct {
 	URI                      string     `json:"uri"`
 }
 
+// Ignition contains location of ignition to be run during bootstrapping
+type Ignition struct {
+	// Ignition config to be run during bootstrapping
+	UserDataSecret string `json:"userDataSecret"`
+}
+
 // CloudInit contains location of user data to be run during bootstrapping
-// with ISO image with a cloud-init file running the user data
 type CloudInit struct {
 	// Bash script to be run during bootstrapping
 	UserDataSecret string `json:"userDataSecret"`

--- a/pkg/cloud/libvirt/actuators/machine/actuator.go
+++ b/pkg/cloud/libvirt/actuators/machine/actuator.go
@@ -181,6 +181,7 @@ func createVolumeAndDomain(codec codec, machine *clusterv1.Machine, offset int, 
 	baseVolume := machineProviderConfig.Volume.BaseVolumeID
 	pool := machineProviderConfig.Volume.PoolName
 	ignKey := machineProviderConfig.IgnKey
+	ignition := machineProviderConfig.Ignition
 	networkInterfaceName := machineProviderConfig.NetworkInterfaceName
 	networkInterfaceAddress := machineProviderConfig.NetworkInterfaceAddress
 	autostart := machineProviderConfig.Autostart
@@ -193,7 +194,7 @@ func createVolumeAndDomain(codec codec, machine *clusterv1.Machine, offset int, 
 	}
 
 	// Create domain
-	if err = libvirtutils.CreateDomain(name, ignKey, name, name, networkInterfaceName, networkInterfaceAddress, pool, autostart, memory, vcpu, offset, client, machineProviderConfig.CloudInit, kubeClient, machine.Namespace); err != nil {
+	if err = libvirtutils.CreateDomain(name, ignKey, ignition, name, name, networkInterfaceName, networkInterfaceAddress, pool, autostart, memory, vcpu, offset, client, machineProviderConfig.CloudInit, kubeClient, machine.Namespace); err != nil {
 		// Clean up the created volume if domain creation fails,
 		// otherwise subsequent runs will fail.
 		if err := libvirtutils.DeleteVolume(name, client); err != nil {
@@ -225,6 +226,11 @@ func deleteVolumeAndDomain(machine *clusterv1.Machine, client *libvirtutils.Clie
 
 	// Delete cloud init volume if exists
 	if err := libvirtutils.EnsureCloudInitVolumeIsDeleted(machine.Name, client); err != nil {
+		return fmt.Errorf("error deleting volume: %v", err)
+	}
+
+	// Delete cloud init volume if exists
+	if err := libvirtutils.EnsureIgnitionVolumeIsDeleted(machine.Name, client); err != nil {
 		return fmt.Errorf("error deleting volume: %v", err)
 	}
 

--- a/pkg/cloud/libvirt/actuators/machine/utils/domain.go
+++ b/pkg/cloud/libvirt/actuators/machine/utils/domain.go
@@ -465,7 +465,7 @@ func domainDefInit(domainDef *libvirtxml.Domain, name string, memory, vcpu int) 
 	return nil
 }
 
-func CreateDomain(name, ignKey, volumeName, hostName, networkInterfaceName, networkInterfaceAddress, poolName string, autostart bool, memory, vcpu, offset int, client *Client, cloudInit *providerconfigv1.CloudInit, kubeClient kubernetes.Interface, machineNamespace string) error {
+func CreateDomain(name, ignKey string, ignition *providerconfigv1.Ignition, volumeName, hostName, networkInterfaceName, networkInterfaceAddress, poolName string, autostart bool, memory, vcpu, offset int, client *Client, cloudInit *providerconfigv1.CloudInit, kubeClient kubernetes.Interface, machineNamespace string) error {
 	if name == "" {
 		return fmt.Errorf("Failed to create domain, name is empty")
 	}
@@ -483,7 +483,11 @@ func CreateDomain(name, ignKey, volumeName, hostName, networkInterfaceName, netw
 	}
 
 	glog.Infof("setCoreOSIgnition")
-	if ignKey != "" {
+	if ignition != nil {
+		if err := SetIgnition(&domainDef, client, ignition, kubeClient, machineNamespace, volumeName, poolName); err != nil {
+			return err
+		}
+	} else if ignKey != "" {
 		if err := setCoreOSIgnition(&domainDef, ignKey); err != nil {
 			return err
 		}


### PR DESCRIPTION
To build:
```
$ make libvirt-actuator
```

To create:
```
$ ./bin/libvirt-actuator --logtostderr create --cluster examples/cluster.yaml --machine examples/machine-with-userdata.yml  --userdata examples/ignition-userdata.yml
```

To delete:
```
$ ./bin/libvirt-actuator delete --cluster examples/cluster.yaml --machine examples/machine-with-userdata.yml  --userdata examples/ignition-userdata.yml --logtostderr
```