### PR TITLE
catch errors and print them

### DIFF
--- a/pkg/cloud/libvirt/actuators/machine/utils/cloudinit.go
+++ b/pkg/cloud/libvirt/actuators/machine/utils/cloudinit.go
@@ -75,6 +75,9 @@ func setCloudInit(domainDef *libvirtxml.Domain, client *Client, cloudInit *provi
 	}
 
 	key, err := cloudInitDef.UploadIso(client, iso)
+	if err != nil {
+		return fmt.Errorf("unable to upload ISO: %v", err)
+	}
 	glog.Infof("key: %+v", key)
 
 	domainDef.Devices.Disks = append(domainDef.Devices.Disks, libvirtxml.DomainDisk{

--- a/pkg/cloud/libvirt/actuators/machine/utils/domain.go
+++ b/pkg/cloud/libvirt/actuators/machine/utils/domain.go
@@ -356,6 +356,9 @@ func setNetworkInterfaces(domainDef *libvirtxml.Domain,
 				return fmt.Errorf("Error retrieving network name: %s", err)
 			}
 			networkDef, err := newDefNetworkfromLibvirt(network)
+			if err != nil {
+				return fmt.Errorf("Error retrieving network definition: %v", err)
+			}
 
 			if HasDHCP(networkDef) {
 				hostname := domainDef.Name

--- a/test/machines/machines_test.go
+++ b/test/machines/machines_test.go
@@ -234,6 +234,9 @@ var _ = framework.SigKubeDescribe("Machines", func() {
 			masterMachinePrivateIP = privateIP
 			return true, nil
 		})
+		if err != nil {
+			glog.Errorf("Unable to get instance ip address: %v", err)
+		}
 
 		glog.V(2).Infof("Master machine running at %v", masterMachinePrivateIP)
 


### PR DESCRIPTION
Some of `err` variables weren't used. This PR catches them and prints messages when they are not `nil`