### PR TITLE
applyMachineStatus: Log changes with ObjectReflectDiff

### DIFF
--- a/pkg/cloud/libvirt/actuators/machine/actuator.go
+++ b/pkg/cloud/libvirt/actuators/machine/actuator.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/client-go/kubernetes"
 
 	corev1 "k8s.io/api/core/v1"
@@ -302,7 +303,7 @@ func (a *Actuator) applyMachineStatus(
 		return nil
 	}
 
-	glog.Infof("Machine %s status has changed, updating", machine.Name)
+	glog.Infof("Machine %s status has changed: %s", machine.Name, diff.ObjectReflectDiff(machine.Status, machineCopy.Status))
 
 	now := metav1.Now()
 	machineCopy.Status.LastUpdated = &now


### PR DESCRIPTION
Because logs like:

```console
$ oc logs --tail=3 -n openshift-cluster-api clusterapi-manager-controllers-6cd5bcf59f-5qm9v -c machine-controller
I1107 05:48:32.040679       1 domain.go:613] Lookup domain by name: "master0"
I1107 05:48:32.040965       1 actuator.go:258] Updating status for master0
I1107 05:48:32.041705       1 actuator.go:305] Machine master0 status has changed, updating
```

are pretty opaque without details about what has changed.

This commit ports openshift/cluster-api-provider-aws@ece3a63a (openshift/cluster-api-provider-aws#93) to the libvirt actuator.

I promise I didn't delay this PR to get it a matching #93 ;).