### PR TITLE
Build separate libvirt client for mocking

### DIFF
--- a/pkg/cloud/libvirt/actuators/machine/utils/client.go
+++ b/pkg/cloud/libvirt/actuators/machine/utils/client.go
@@ -1,0 +1,94 @@
+package utils
+
+import (
+	"github.com/golang/glog"
+	libvirt "github.com/libvirt/libvirt-go"
+	"github.com/openshift/cluster-api-provider-libvirt/pkg/cloud/libvirt/client"
+)
+
+// Client libvirt
+type Client struct {
+	connection *libvirt.Connect
+}
+
+var _ client.Client = &Client{}
+
+// Close closes the client's libvirt connection.
+func (client *Client) Close() error {
+	glog.Infof("Closing libvirt connection: %p", client.connection)
+
+	_, err := client.connection.Close()
+	if err != nil {
+		glog.Infof("Error closing libvirt connection: %v", err)
+	}
+
+	return err
+}
+
+// CreateDomain creates domain based on CreateDomainInput
+func (client *Client) CreateDomain(input *client.CreateDomainInput) error {
+	return CreateDomain(
+		input.DomainName,
+		input.IgnKey,
+		input.Ignition,
+		input.VolumeName,
+		input.HostName,
+		input.NetworkInterfaceName,
+		input.NetworkInterfaceAddress,
+		input.VolumePoolName,
+		input.Autostart,
+		input.DomainMemory,
+		input.DomainVcpu,
+		input.Offset,
+		client,
+		input.CloudInit,
+		input.KubeClient,
+		input.MachineNamespace)
+}
+
+// LookupDomainByName looks up a domain based on its name
+func (client *Client) LookupDomainByName(name string) (*libvirt.Domain, error) {
+	return LookupDomainByName(name, client)
+}
+
+// DomainExists checks if domain exists
+func (client *Client) DomainExists(name string) (bool, error) {
+	return DomainExists(name, client)
+}
+
+// DeleteDomain deletes a domain
+func (client *Client) DeleteDomain(name string) error {
+	exists, err := DomainExists(name, client)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return ErrDomainNotFound
+	}
+	return DeleteDomain(name, client)
+}
+
+// CreateVolume creates volume based on CreateVolumeInput
+func (client *Client) CreateVolume(input *client.CreateVolumeInput) error {
+	return CreateVolume(
+		input.VolumeName,
+		input.PoolName,
+		input.BaseVolumeID,
+		input.Source,
+		input.VolumeFormat,
+		client,
+	)
+}
+
+// DeleteVolume deletes a domain based on its name
+func (client *Client) DeleteVolume(name string) error {
+	exists, err := VolumeExists(name, client)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		glog.Infof("Volume %s does not exists", name)
+		return ErrVolumeNotFound
+	}
+	return DeleteVolume(name, client)
+}

--- a/pkg/cloud/libvirt/actuators/machine/utils/client.go
+++ b/pkg/cloud/libvirt/actuators/machine/utils/client.go
@@ -26,7 +26,7 @@ func (client *Client) Close() error {
 }
 
 // CreateDomain creates domain based on CreateDomainInput
-func (client *Client) CreateDomain(input *client.CreateDomainInput) error {
+func (client *Client) CreateDomain(input client.CreateDomainInput) error {
 	return CreateDomain(
 		input.DomainName,
 		input.IgnKey,
@@ -39,7 +39,7 @@ func (client *Client) CreateDomain(input *client.CreateDomainInput) error {
 		input.Autostart,
 		input.DomainMemory,
 		input.DomainVcpu,
-		input.Offset,
+		input.AddressRange,
 		client,
 		input.CloudInit,
 		input.KubeClient,
@@ -69,7 +69,7 @@ func (client *Client) DeleteDomain(name string) error {
 }
 
 // CreateVolume creates volume based on CreateVolumeInput
-func (client *Client) CreateVolume(input *client.CreateVolumeInput) error {
+func (client *Client) CreateVolume(input client.CreateVolumeInput) error {
 	return CreateVolume(
 		input.VolumeName,
 		input.PoolName,

--- a/pkg/cloud/libvirt/actuators/machine/utils/cloudinit.go
+++ b/pkg/cloud/libvirt/actuators/machine/utils/cloudinit.go
@@ -20,12 +20,8 @@ import (
 	providerconfigv1 "github.com/openshift/cluster-api-provider-libvirt/pkg/apis/libvirtproviderconfig/v1alpha1"
 )
 
-func getCloudInitVolumeName(volumeName string) string {
+func CloudInitVolumeName(volumeName string) string {
 	return fmt.Sprintf("%v_cloud-init", volumeName)
-}
-
-func EnsureCloudInitVolumeIsDeleted(name string, client *Client) error {
-	return EnsureVolumeIsDeleted(getCloudInitVolumeName(name), client)
 }
 
 func setCloudInit(domainDef *libvirtxml.Domain, client *Client, cloudInit *providerconfigv1.CloudInit, kubeClient kubernetes.Interface, machineNamespace, volumeName, poolName string) error {
@@ -59,7 +55,7 @@ func setCloudInit(domainDef *libvirtxml.Domain, client *Client, cloudInit *provi
 		return fmt.Errorf("can not render cloud init meta-data: %v", err)
 	}
 
-	cloudInitISOName := getCloudInitVolumeName(volumeName)
+	cloudInitISOName := CloudInitVolumeName(volumeName)
 
 	cloudInitDef := newCloudInitDef()
 	cloudInitDef.UserData = string(userData)

--- a/pkg/cloud/libvirt/actuators/machine/utils/domain.go
+++ b/pkg/cloud/libvirt/actuators/machine/utils/domain.go
@@ -30,25 +30,11 @@ const (
 // ErrLibVirtConIsNil is returned when the libvirt connection is nil.
 var ErrLibVirtConIsNil = errors.New("the libvirt connection was nil")
 
+// ErrDomainNotFound is returned when a domain is not found
+var ErrDomainNotFound = errors.New("Domain not found")
+
 func init() {
 	rand.Seed(time.Now().UTC().UnixNano())
-}
-
-// Client libvirt
-type Client struct {
-	connection *libvirt.Connect
-}
-
-// Close closes the client's libvirt connection.
-func (c *Client) Close() error {
-	glog.Infof("Closing libvirt connection: %p", c.connection)
-
-	_, err := c.connection.Close()
-	if err != nil {
-		glog.Infof("Error closing libvirt connection: %v", err)
-	}
-
-	return err
 }
 
 type pendingMapping struct {

--- a/pkg/cloud/libvirt/actuators/machine/utils/ignition.go
+++ b/pkg/cloud/libvirt/actuators/machine/utils/ignition.go
@@ -17,12 +17,8 @@ import (
 	providerconfigv1 "github.com/openshift/cluster-api-provider-libvirt/pkg/apis/libvirtproviderconfig/v1alpha1"
 )
 
-func getIgnitionVolumeName(volumeName string) string {
+func IgnitionVolumeName(volumeName string) string {
 	return fmt.Sprintf("%v.ignition", volumeName)
-}
-
-func EnsureIgnitionVolumeIsDeleted(name string, client *Client) error {
-	return EnsureVolumeIsDeleted(getIgnitionVolumeName(name), client)
 }
 
 func SetIgnition(domainDef *libvirtxml.Domain, client *Client, ignition *providerconfigv1.Ignition, kubeClient kubernetes.Interface, machineNamespace, volumeName, poolName string) error {
@@ -42,7 +38,7 @@ func SetIgnition(domainDef *libvirtxml.Domain, client *Client, ignition *provide
 		return fmt.Errorf("can not retrieve user data secret '%v/%v' when constructing cloud init volume: key 'userData' not found in the secret", machineNamespace, ignition.UserDataSecret)
 	}
 
-	ignitionDef.Name = getIgnitionVolumeName(volumeName)
+	ignitionDef.Name = IgnitionVolumeName(volumeName)
 	ignitionDef.PoolName = poolName
 	ignitionDef.Content = string(userDataSecret)
 

--- a/pkg/cloud/libvirt/actuators/machine/utils/volume.go
+++ b/pkg/cloud/libvirt/actuators/machine/utils/volume.go
@@ -201,18 +201,6 @@ func CreateVolume(volumeName, poolName, baseVolumeID, source, volumeFormat strin
 	return nil
 }
 
-func EnsureVolumeIsDeleted(volumeName string, client *Client) error {
-	exists, err := VolumeExists(volumeName, client)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		glog.Infof("Volume %s does not exists", volumeName)
-		return nil
-	}
-	return DeleteVolume(volumeName, client)
-}
-
 // VolumeExists checks if a volume exists
 func VolumeExists(volumeName string, client *Client) (bool, error) {
 	glog.Infof("Check if %q volume exists", volumeName)

--- a/pkg/cloud/libvirt/actuators/machine/utils/volume.go
+++ b/pkg/cloud/libvirt/actuators/machine/utils/volume.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -17,6 +18,9 @@ const (
 	// TODO: support size in the API
 	size = 17706254336
 )
+
+// ErrVolumeNotFound is returned when a domain is not found
+var ErrVolumeNotFound = errors.New("Domain not found")
 
 // WaitSleepInterval time
 var WaitSleepInterval = 1 * time.Second

--- a/pkg/cloud/libvirt/client/client.go
+++ b/pkg/cloud/libvirt/client/client.go
@@ -1,0 +1,97 @@
+package client
+
+import (
+	libvirt "github.com/libvirt/libvirt-go"
+	providerconfigv1 "github.com/openshift/cluster-api-provider-libvirt/pkg/apis/libvirtproviderconfig/v1alpha1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// CreateDomainInput specifies input parameters for CreateDomain operation
+type CreateDomainInput struct {
+	// DomainName is name of domain to be created
+	DomainName string
+
+	// IgnKey is name of existing volume with ignition config (DEPRECATED)
+	IgnKey string
+
+	// Ignition configuration to be injected during bootstrapping
+	Ignition *providerconfigv1.Ignition
+
+	// CloudInit configuration to be run during bootstrapping
+	CloudInit *providerconfigv1.CloudInit
+
+	// VolumeName of volume to be added to domain definition
+	VolumeName string
+
+	// VolumePoolName of pool where VolumeName volume is located
+	VolumePoolName string
+
+	// NetworkInterfaceName as name of network interface
+	NetworkInterfaceName string
+
+	// NetworkInterfaceAddress as address of network interface
+	NetworkInterfaceAddress string
+
+	// HostName as network interface hostname
+	HostName string
+
+	// AddressRange as IP subnet address range
+	AddressRange int
+
+	// Autostart as domain autostart
+	Autostart bool
+
+	// DomainMemory allocated for running domain
+	DomainMemory int
+
+	// DomainVcpu allocated for running domain
+	DomainVcpu int
+
+	// KubeClient as kubernetes client
+	KubeClient kubernetes.Interface
+
+	// MachineNamespace with machine object
+	MachineNamespace string
+}
+
+// CreateVolumeInput specifies input parameters for CreateVolume operation
+type CreateVolumeInput struct {
+	// VolumeName to be created
+	VolumeName string
+
+	// PoolName where VolumeName volume is located
+	PoolName string
+
+	// BaseVolumeID as base volume ID
+	BaseVolumeID string
+
+	// Source as location of base volume
+	Source string
+
+	// VolumeFormat as volume format
+	VolumeFormat string
+}
+
+// Client is a wrapper object for actual libvirt library to allow for easier testing.
+type Client interface {
+	// Close closes the client's libvirt connection.
+	Close() error
+
+	// CreateDomain creates domain based on CreateDomainInput
+	CreateDomain(CreateDomainInput) error
+
+	// DeleteDomain deletes a domain
+	DeleteDomain(name string) error
+
+	// DomainExists checks if domain exists
+	DomainExists(name string) (bool, error)
+
+	// LookupDomainByName looks up a domain based on its name
+	LookupDomainByName(name string) (*libvirt.Domain, error)
+
+	// CreateVolume creates volume based on CreateVolumeInput
+	CreateVolume(CreateVolumeInput) error
+
+	// DeleteVolume deletes a domain based on its name
+	DeleteVolume(name string) error
+}


### PR DESCRIPTION
Must before we can build mock the client and test the libvirt actuator operations in unit tests.