### PR TITLE
Remove providerconfig

### DIFF
--- a/cmd/libvirt-actuator/README.md
+++ b/cmd/libvirt-actuator/README.md
@@ -39,10 +39,10 @@ contains a shell script that deploys kubernetes master node.
 Feel free to modify the file to your needs.
 
 The libvirt actuator expects the user data to be provided by a kubernetes secret
-by setting `spec.providerConfig.value.cloudInit.userDataSecret` field.
+by setting `spec.providerSpec.value.cloudInit.userDataSecret` field.
 See [userdata.yml](../../examples/userdata.yml) for example.
 
-At the same time, the `spec.providerConfig.value.uri` needs to be set to libvirt
+At the same time, the `spec.providerSpec.value.uri` needs to be set to libvirt
 uri. E.g. `qemu+ssh://root@147.75.96.139/system` in case the libivrt instance
 is accessible via ssh on `147.75.96.139` IP address.
 

--- a/cmd/libvirt-actuator/main.go
+++ b/cmd/libvirt-actuator/main.go
@@ -240,11 +240,11 @@ func bootstrapCommand() *cobra.Command {
 				return err
 			}
 
-			masterMachineProviderConfig, err := testutils.MasterMachineProviderConfig(masterUserDataSecret.Name, libvirturi)
+			masterMachineProviderSpec, err := testutils.MasterMachineProviderSpec(masterUserDataSecret.Name, libvirturi)
 			if err != nil {
 				return err
 			}
-			masterMachine := manifests.MasterMachine(testCluster.Name, testCluster.Namespace, masterMachineProviderConfig)
+			masterMachine := manifests.MasterMachine(testCluster.Name, testCluster.Namespace, masterMachineProviderSpec)
 
 			glog.Infof("Creating master machine")
 
@@ -340,11 +340,11 @@ func bootstrapCommand() *cobra.Command {
 			}
 
 			createSecretAndWait(clusterFramework, workerUserDataSecret)
-			workerMachineSetProviderConfig, err := testutils.WorkerMachineProviderConfig(workerUserDataSecret.Name, inclusterlibvirturi)
+			workerMachineSetProviderSpec, err := testutils.WorkerMachineProviderSpec(workerUserDataSecret.Name, inclusterlibvirturi)
 			if err != nil {
 				return err
 			}
-			workerMachineSet := manifests.WorkerMachineSet(testCluster.Name, testCluster.Namespace, workerMachineSetProviderConfig)
+			workerMachineSet := manifests.WorkerMachineSet(testCluster.Name, testCluster.Namespace, workerMachineSetProviderSpec)
 			clusterFramework.CreateMachineSetAndWait(workerMachineSet, lcw)
 
 			return nil

--- a/pkg/apis/libvirtproviderconfig/v1alpha1/libvirtmachineproviderconfig_types.go
+++ b/pkg/apis/libvirtproviderconfig/v1alpha1/libvirtmachineproviderconfig_types.go
@@ -14,7 +14,7 @@ const (
 	MachineTypeLabel = "sigs.k8s.io/cluster-api-machine-type"
 )
 
-// LibvirtMachineProviderConfig is the type that will be embedded in a Machine.Spec.ProviderConfig field
+// LibvirtMachineProviderConfig is the type that will be embedded in a Machine.Spec.ProviderSpec field
 // for an Libvirt instance.
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type LibvirtMachineProviderConfig struct {
@@ -55,7 +55,7 @@ type Volume struct {
 	VolumeName   string `json:"volumeName"`
 }
 
-// LibvirtClusterProviderConfig is the type that will be embedded in a Cluster.Spec.ProviderConfig field.
+// LibvirtClusterProviderConfig is the type that will be embedded in a Cluster.Spec.ProviderSpec field.
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type LibvirtClusterProviderConfig struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/libvirtproviderconfig/v1alpha1/register.go
+++ b/pkg/apis/libvirtproviderconfig/v1alpha1/register.go
@@ -58,8 +58,8 @@ func NewCodec() (*LibvirtProviderConfigCodec, error) {
 	return &codec, nil
 }
 
-// DecodeFromProviderConfig decodes a serialised ProviderConfig into an object
-func (codec *LibvirtProviderConfigCodec) DecodeFromProviderConfig(providerConfig clusterv1alpha1.ProviderSpec, out runtime.Object) error {
+// DecodeFromProviderSpec decodes a serialised ProviderConfig into an object
+func (codec *LibvirtProviderConfigCodec) DecodeFromProviderSpec(providerConfig clusterv1alpha1.ProviderSpec, out runtime.Object) error {
 	if providerConfig.Value != nil {
 		_, _, err := codec.decoder.Decode(providerConfig.Value.Raw, nil, out)
 		if err != nil {
@@ -69,8 +69,8 @@ func (codec *LibvirtProviderConfigCodec) DecodeFromProviderConfig(providerConfig
 	return nil
 }
 
-// EncodeToProviderConfig encodes an object into a serialised ProviderConfig
-func (codec *LibvirtProviderConfigCodec) EncodeToProviderConfig(in runtime.Object) (*clusterv1alpha1.ProviderSpec, error) {
+// EncodeToProviderSpec encodes an object into a serialised ProviderConfig
+func (codec *LibvirtProviderConfigCodec) EncodeToProviderSpec(in runtime.Object) (*clusterv1alpha1.ProviderSpec, error) {
 	var buf bytes.Buffer
 	if err := codec.encoder.Encode(in, &buf); err != nil {
 		return nil, fmt.Errorf("encoding failed: %v", err)

--- a/pkg/cloud/libvirt/actuators/machine/actuator.go
+++ b/pkg/cloud/libvirt/actuators/machine/actuator.go
@@ -308,16 +308,7 @@ func (a *Actuator) deleteVolumeAndDomain(machine *clusterv1.Machine, client libv
 // ProviderConfigMachine gets the machine provider config MachineSetSpec from the
 // specified cluster-api MachineSpec.
 func ProviderConfigMachine(codec codec, ms *clusterv1.MachineSpec) (*providerconfigv1.LibvirtMachineProviderConfig, error) {
-	// TODO(jchaloup): Remove providerConfig once all consumers migrate to providerSpec
-	providerSpec := ms.ProviderConfig
-	// providerSpec has higher priority over providerConfig
-	if ms.ProviderSpec.Value != nil || ms.ProviderSpec.ValueFrom != nil {
-		providerSpec = ms.ProviderSpec
-		glog.Infof("Falling to default providerSpec\n")
-	} else {
-		glog.Infof("Falling to providerConfig\n")
-	}
-
+	providerSpec := ms.ProviderSpec
 	if providerSpec.Value == nil {
 		return nil, fmt.Errorf("no Value in ProviderConfig")
 	}

--- a/pkg/cloud/libvirt/actuators/machine/actuator.go
+++ b/pkg/cloud/libvirt/actuators/machine/actuator.go
@@ -65,7 +65,7 @@ type Actuator struct {
 }
 
 type codec interface {
-	DecodeFromProviderConfig(clusterv1.ProviderSpec, runtime.Object) error
+	DecodeFromProviderSpec(clusterv1.ProviderSpec, runtime.Object) error
 	DecodeProviderStatus(*runtime.RawExtension, runtime.Object) error
 	EncodeProviderStatus(runtime.Object) (*runtime.RawExtension, error)
 }
@@ -314,7 +314,7 @@ func ProviderConfigMachine(codec codec, ms *clusterv1.MachineSpec) (*providercon
 	}
 
 	var config providerconfigv1.LibvirtMachineProviderConfig
-	if err := codec.DecodeFromProviderConfig(providerSpec, &config); err != nil {
+	if err := codec.DecodeFromProviderSpec(providerSpec, &config); err != nil {
 		return nil, err
 	}
 

--- a/pkg/cloud/libvirt/actuators/machine/stubs.go
+++ b/pkg/cloud/libvirt/actuators/machine/stubs.go
@@ -41,7 +41,7 @@ func stubMachine() (*clusterv1.Machine, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed creating codec: %v", err)
 	}
-	config, err := codec.EncodeToProviderConfig(machinePc)
+	config, err := codec.EncodeToProviderSpec(machinePc)
 	if err != nil {
 		return nil, fmt.Errorf("encodeToProviderConfig failed: %v", err)
 	}

--- a/test/machines/machines_test.go
+++ b/test/machines/machines_test.go
@@ -145,9 +145,9 @@ var _ = framework.SigKubeDescribe("Machines", func() {
 			f.CreateClusterAndWait(cluster)
 
 			// Create/delete a single machine, test instance is provisioned/terminated
-			testMachineProviderConfig, err := utils.TestingMachineProviderConfig(f.LibvirtURI, cluster.Name)
+			testMachineProviderSpec, err := utils.TestingMachineProviderSpec(f.LibvirtURI, cluster.Name)
 			Expect(err).NotTo(HaveOccurred())
-			testMachine := manifests.TestingMachine(cluster.Name, cluster.Namespace, testMachineProviderConfig)
+			testMachine := manifests.TestingMachine(cluster.Name, cluster.Namespace, testMachineProviderSpec)
 			lcw, err := NewLibvirtClient("qemu:///system")
 			Expect(err).NotTo(HaveOccurred())
 
@@ -215,9 +215,9 @@ var _ = framework.SigKubeDescribe("Machines", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		createSecretAndWait(f, masterUserDataSecret)
-		masterMachineProviderConfig, err := utils.MasterMachineProviderConfig(masterUserDataSecret.Name, f.LibvirtURI)
+		masterMachineProviderSpec, err := utils.MasterMachineProviderSpec(masterUserDataSecret.Name, f.LibvirtURI)
 		Expect(err).NotTo(HaveOccurred())
-		masterMachine := manifests.MasterMachine(cluster.Name, cluster.Namespace, masterMachineProviderConfig)
+		masterMachine := manifests.MasterMachine(cluster.Name, cluster.Namespace, masterMachineProviderSpec)
 		lcw, err := NewLibvirtClient("qemu:///system")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -282,9 +282,9 @@ var _ = framework.SigKubeDescribe("Machines", func() {
 		workerUserDataSecret, err := manifests.WorkerMachineUserDataSecret("workeruserdatasecret", testNamespace.Name, masterPrivateIP)
 		Expect(err).NotTo(HaveOccurred())
 		createSecretAndWait(clusterFramework, workerUserDataSecret)
-		workerMachineSetProviderConfig, err := utils.WorkerMachineProviderConfig(workerUserDataSecret.Name, f.LibvirtURI)
+		workerMachineSetProviderSpec, err := utils.WorkerMachineProviderSpec(workerUserDataSecret.Name, f.LibvirtURI)
 		Expect(err).NotTo(HaveOccurred())
-		workerMachineSet := manifests.WorkerMachineSet(cluster.Name, cluster.Namespace, workerMachineSetProviderConfig)
+		workerMachineSet := manifests.WorkerMachineSet(cluster.Name, cluster.Namespace, workerMachineSetProviderSpec)
 
 		clusterFramework.CreateMachineSetAndWait(workerMachineSet, lcw)
 		machinesToDelete.AddMachineSet(workerMachineSet, clusterFramework, lcw)

--- a/test/utils/manifests.go
+++ b/test/utils/manifests.go
@@ -7,7 +7,7 @@ import (
 	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
-func TestingMachineProviderConfig(uri, clusterID string) (clusterv1alpha1.ProviderSpec, error) {
+func TestingMachineProviderSpec(uri, clusterID string) (clusterv1alpha1.ProviderSpec, error) {
 	machinePc := &providerconfigv1.LibvirtMachineProviderConfig{
 		DomainMemory: 2048,
 		DomainVcpu:   1,
@@ -28,14 +28,14 @@ func TestingMachineProviderConfig(uri, clusterID string) (clusterv1alpha1.Provid
 	if err != nil {
 		return clusterv1alpha1.ProviderSpec{}, fmt.Errorf("failed creating codec: %v", err)
 	}
-	config, err := codec.EncodeToProviderConfig(machinePc)
+	config, err := codec.EncodeToProviderSpec(machinePc)
 	if err != nil {
-		return clusterv1alpha1.ProviderSpec{}, fmt.Errorf("EncodeToProviderConfig failed: %v", err)
+		return clusterv1alpha1.ProviderSpec{}, fmt.Errorf("codec.EncodeToProviderSpec failed: %v", err)
 	}
 	return *config, nil
 }
 
-func MasterMachineProviderConfig(masterUserDataSecret, libvirturi string) (clusterv1alpha1.ProviderSpec, error) {
+func MasterMachineProviderSpec(masterUserDataSecret, libvirturi string) (clusterv1alpha1.ProviderSpec, error) {
 	machinePc := &providerconfigv1.LibvirtMachineProviderConfig{
 		DomainMemory: 2048,
 		DomainVcpu:   2,
@@ -57,13 +57,13 @@ func MasterMachineProviderConfig(masterUserDataSecret, libvirturi string) (clust
 	if err != nil {
 		return clusterv1alpha1.ProviderSpec{}, fmt.Errorf("failed creating codec: %v", err)
 	}
-	config, err := codec.EncodeToProviderConfig(machinePc)
+	config, err := codec.EncodeToProviderSpec(machinePc)
 	if err != nil {
-		return clusterv1alpha1.ProviderSpec{}, fmt.Errorf("EncodeToProviderConfig failed: %v", err)
+		return clusterv1alpha1.ProviderSpec{}, fmt.Errorf("codec.EncodeToProviderSpec failed: %v", err)
 	}
 	return *config, nil
 }
 
-func WorkerMachineProviderConfig(workerUserDataSecret, libvirturi string) (clusterv1alpha1.ProviderSpec, error) {
-	return MasterMachineProviderConfig(workerUserDataSecret, libvirturi)
+func WorkerMachineProviderSpec(workerUserDataSecret, libvirturi string) (clusterv1alpha1.ProviderSpec, error) {
+	return MasterMachineProviderSpec(workerUserDataSecret, libvirturi)
 }

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -63,10 +63,6 @@ type MachineSpec struct {
 	// +optional
 	ProviderSpec ProviderSpec `json:"providerSpec"`
 
-	// Provider-specific configuration to use during node creation.
-	// +optional
-	ProviderConfig ProviderSpec `json:"providerConfig"`
-
 	// Versions of key software to use. This field is optional at cluster
 	// creation time, and omitting the field indicates that the cluster
 	// installation tool should select defaults for the user. These

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
@@ -632,7 +632,6 @@ func (in *MachineSpec) DeepCopyInto(out *MachineSpec) {
 		}
 	}
 	in.ProviderSpec.DeepCopyInto(&out.ProviderSpec)
-	in.ProviderConfig.DeepCopyInto(&out.ProviderConfig)
 	out.Versions = in.Versions
 	if in.ConfigSource != nil {
 		in, out := &in.ConfigSource, &out.ConfigSource


### PR DESCRIPTION
- remove any use of the `.providerConfig` and `ProviderConfig`
- rename testing resources to reflect new provider spec name
- rename [Encode|Decode]ProviderConfig to [Encode|Decode]ProviderSpec

To be merged not before https://github.com/openshift/machine-api-operator/pull/173