### PR TITLE
Validate machineset before reconciling

### DIFF
--- a/0001-Validate-machineset-before-reconciliation.patch
+++ b/0001-Validate-machineset-before-reconciliation.patch
@@ -1,0 +1,30 @@
+From 3200e454110d91955ab849c75db5ee60085c8991 Mon Sep 17 00:00:00 2001
+From: Jan Chaloupka <jchaloup@redhat.com>
+Date: Fri, 11 Jan 2019 12:31:06 +0100
+Subject: [PATCH] Validate machineset before reconciliation
+
+---
+ .../cluster-api/pkg/controller/machineset/controller.go            | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/vendor/sigs.k8s.io/cluster-api/pkg/controller/machineset/controller.go b/vendor/sigs.k8s.io/cluster-api/pkg/controller/machineset/controller.go
+index a1d3923..cb537bd 100644
+--- a/vendor/sigs.k8s.io/cluster-api/pkg/controller/machineset/controller.go
++++ b/vendor/sigs.k8s.io/cluster-api/pkg/controller/machineset/controller.go
+@@ -150,6 +150,13 @@ func (r *ReconcileMachineSet) Reconcile(request reconcile.Request) (reconcile.Re
+ 	}
+ 
+ 	klog.V(4).Infof("Reconcile machineset %v", machineSet.Name)
++
++	if errList := machineSet.Validate(); len(errList) > 0 {
++		err := fmt.Errorf("%q machineset validation failed: %v", machineSet.Name, errList.ToAggregate().Error())
++		klog.Error(err)
++		return reconcile.Result{}, err
++	}
++
+ 	allMachines := &clusterv1alpha1.MachineList{}
+ 
+ 	err = r.Client.List(context.Background(), client.InNamespace(machineSet.Namespace), allMachines)
+-- 
+2.7.5
+

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ vendor:
 	dep ensure -v
 	patch -p1 < 0001-Delete-annotated-machines-first-when-scaling-down.patch
 	patch -p1 < 0002-Sort-machines-before-syncing.patch
-#	patch -p1 < 0001-use-Update-instead-of-Status.Update-as-CustomResourc.patch
+	patch -p1 < 0001-Validate-machineset-before-reconciliation.patch
 
 .PHONY: generate
 generate: gendeepcopy

--- a/vendor/sigs.k8s.io/cluster-api/pkg/controller/machineset/controller.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/controller/machineset/controller.go
@@ -151,6 +151,13 @@ func (r *ReconcileMachineSet) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	klog.V(4).Infof("Reconcile machineset %v", machineSet.Name)
+
+	if errList := machineSet.Validate(); len(errList) > 0 {
+		err := fmt.Errorf("%q machineset validation failed: %v", machineSet.Name, errList.ToAggregate().Error())
+		klog.Error(err)
+		return reconcile.Result{}, err
+	}
+
 	allMachines := &clusterv1alpha1.MachineList{}
 
 	err = r.Client.List(context.Background(), client.InNamespace(machineSet.Namespace), allMachines)


### PR DESCRIPTION
Even thought the MachineSet type implements Validate() function,
it's not called by default. The validation function is responsible
for making sure every machine set matchLabels selector is matched with
machine template labels. Given the validation is not performed by default,
it is possible to create an invalid machineset that causes the machineset
controller to start creating machine object one by one without any upper
bound. Causing the machine controller to launch as many instances as
there is machine objects.

Carried as downstream patch before kubernetes-sigs/cluster-api#669 gets resolved.