### PR TITLE
Initialize klog alongside with glog

### DIFF
--- a/0001-Upstream-677-Init-klog-in-manager-properly.patch
+++ b/0001-Upstream-677-Init-klog-in-manager-properly.patch
@@ -1,0 +1,103 @@
+From f8f05443cf2774f22484fda02a5edac4a1251713 Mon Sep 17 00:00:00 2001
+From: Jan Chaloupka <jchaloup@redhat.com>
+Date: Tue, 15 Jan 2019 10:28:40 +0100
+Subject: [PATCH 1/3] Upstream: 677: Init klog in manager properly
+
+---
+ ...pstream-677-Init-klog-in-manager-properly.patch | 41 ++++++++++++++++++++++
+ Makefile                                           |  1 +
+ vendor/sigs.k8s.io/cluster-api/cmd/manager/main.go | 10 ++++++
+ 3 files changed, 52 insertions(+)
+ create mode 100644 0001-Upstream-677-Init-klog-in-manager-properly.patch
+
+diff --git a/0001-Upstream-677-Init-klog-in-manager-properly.patch b/0001-Upstream-677-Init-klog-in-manager-properly.patch
+new file mode 100644
+index 0000000..dca0f54
+--- /dev/null
++++ b/0001-Upstream-677-Init-klog-in-manager-properly.patch
+@@ -0,0 +1,41 @@
++From 6376c57e840a5ff57217ead3dd2633ee00c08d07 Mon Sep 17 00:00:00 2001
++From: Jan Chaloupka <jchaloup@redhat.com>
++Date: Tue, 15 Jan 2019 10:28:40 +0100
++Subject: [PATCH] Upstream: 677: Init klog in manager properly
++
++---
++ vendor/sigs.k8s.io/cluster-api/cmd/manager/main.go | 10 ++++++++++
++ 1 file changed, 10 insertions(+)
++
++diff --git a/vendor/sigs.k8s.io/cluster-api/cmd/manager/main.go b/vendor/sigs.k8s.io/cluster-api/cmd/manager/main.go
++index 6c53802..6082803 100644
++--- a/vendor/sigs.k8s.io/cluster-api/cmd/manager/main.go
+++++ b/vendor/sigs.k8s.io/cluster-api/cmd/manager/main.go
++@@ -22,6 +22,7 @@ import (
++ 	"flag"
++ 
++ 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+++	"k8s.io/klog"
++ 	"sigs.k8s.io/cluster-api/pkg/apis"
++ 	"sigs.k8s.io/cluster-api/pkg/controller"
++ 	"sigs.k8s.io/controller-runtime/pkg/client/config"
++@@ -30,7 +31,16 @@ import (
++ )
++ 
++ func main() {
+++	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+++	klog.InitFlags(klogFlags)
++ 	flag.Parse()
+++	flag.VisitAll(func(f1 *flag.Flag) {
+++		f2 := klogFlags.Lookup(f1.Name)
+++		if f2 != nil {
+++			value := f1.Value.String()
+++			f2.Value.Set(value)
+++		}
+++	})
++ 
++ 	// Get a config to talk to the apiserver
++ 	cfg, err := config.GetConfig()
++-- 
++2.7.5
++
+diff --git a/Makefile b/Makefile
+index 142c6ca..330c662 100644
+--- a/Makefile
++++ b/Makefile
+@@ -47,6 +47,7 @@ vendor:
+ 	patch -p1 < 0001-Delete-annotated-machines-first-when-scaling-down.patch
+ 	patch -p1 < 0002-Sort-machines-before-syncing.patch
+ 	patch -p1 < 0001-Validate-machineset-before-reconciliation.patch
++	patch -p1 < 0001-Upstream-677-Init-klog-in-manager-properly.patch
+ 
+ .PHONY: generate
+ generate:
+diff --git a/vendor/sigs.k8s.io/cluster-api/cmd/manager/main.go b/vendor/sigs.k8s.io/cluster-api/cmd/manager/main.go
+index 6c53802..6082803 100644
+--- a/vendor/sigs.k8s.io/cluster-api/cmd/manager/main.go
++++ b/vendor/sigs.k8s.io/cluster-api/cmd/manager/main.go
+@@ -22,6 +22,7 @@ import (
+ 	"flag"
+ 
+ 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
++	"k8s.io/klog"
+ 	"sigs.k8s.io/cluster-api/pkg/apis"
+ 	"sigs.k8s.io/cluster-api/pkg/controller"
+ 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+@@ -30,7 +31,16 @@ import (
+ )
+ 
+ func main() {
++	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
++	klog.InitFlags(klogFlags)
+ 	flag.Parse()
++	flag.VisitAll(func(f1 *flag.Flag) {
++		f2 := klogFlags.Lookup(f1.Name)
++		if f2 != nil {
++			value := f1.Value.String()
++			f2.Value.Set(value)
++		}
++	})
+ 
+ 	// Get a config to talk to the apiserver
+ 	cfg, err := config.GetConfig()
+-- 
+2.7.5
+

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ gendeepcopy:
 .PHONY: build
 build: ## build binaries
 	$(DOCKER_CMD) go build $(GOGCFLAGS) -o bin/machine-controller github.com/openshift/cluster-api-provider-libvirt/cmd/manager
+	$(DOCKER_CMD) go build $(GOGCFLAGS) -o bin/manager github.com/openshift/cluster-api-provider-libvirt/vendor/sigs.k8s.io/cluster-api/cmd/manager
 	$(DOCKER_CMD) go test $(GOGCFLAGS) -c -o bin/machines.test github.com/openshift/cluster-api-provider-libvirt/test/machines
 
 .PHONY: libvirt-actuator

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ vendor:
 	patch -p1 < 0001-Delete-annotated-machines-first-when-scaling-down.patch
 	patch -p1 < 0002-Sort-machines-before-syncing.patch
 	patch -p1 < 0001-Validate-machineset-before-reconciliation.patch
+	patch -p1 < 0001-Upstream-677-Init-klog-in-manager-properly.patch
 
 .PHONY: generate
 generate: gendeepcopy

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -17,12 +17,20 @@ import (
 	"flag"
 
 	"github.com/golang/glog"
+	"k8s.io/klog"
 )
 
 func main() {
-	// the following line exists to make glog happy, for more information, see: https://github.com/kubernetes/kubernetes/issues/17162
-	//flag.CommandLine.Parse([]string{})
+	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(klogFlags)
 	flag.Parse()
+	flag.VisitAll(func(f1 *flag.Flag) {
+		f2 := klogFlags.Lookup(f1.Name)
+		if f2 != nil {
+			value := f1.Value.String()
+			f2.Value.Set(value)
+		}
+	})
 
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()

--- a/vendor/sigs.k8s.io/cluster-api/cmd/manager/main.go
+++ b/vendor/sigs.k8s.io/cluster-api/cmd/manager/main.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/klog"
 	"sigs.k8s.io/cluster-api/pkg/apis"
 	"sigs.k8s.io/cluster-api/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -30,7 +31,16 @@ import (
 )
 
 func main() {
+	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(klogFlags)
 	flag.Parse()
+	flag.VisitAll(func(f1 *flag.Flag) {
+		f2 := klogFlags.Lookup(f1.Name)
+		if f2 != nil {
+			value := f1.Value.String()
+			f2.Value.Set(value)
+		}
+	})
 
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()


### PR DESCRIPTION
Resolving https://github.com/kubernetes-sigs/cluster-api/issues/607 for
machine controller and controller manager.

Until glog is migrated to klog, the klog flags need to be
synchronized with glog ones. Otherwise, glog shadows klog flags.

Upstream issue: https://github.com/kubernetes-sigs/cluster-api/pull/677