### PR TITLE
image: add libvirt-devel package to Dockerfile

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,4 +1,6 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
+RUN yum install -y libvirt-devel
+
 WORKDIR /go/src/github.com/openshift/cluster-api-provider-libvirt
 COPY . .
 RUN go build -o machine-controller-manager ./cmd/manager


### PR DESCRIPTION
This package is installed in image used for okd builds, but it is not present in openshift images. 