### PR TITLE
report hostname for machine

### DIFF
--- a/pkg/cloud/libvirt/actuators/machine/actuator.go
+++ b/pkg/cloud/libvirt/actuators/machine/actuator.go
@@ -465,6 +465,15 @@ func NodeAddresses(dom *libvirt.Domain) ([]corev1.NodeAddress, error) {
 		}
 	}
 
+	hostname, err := dom.GetHostname(0)
+	if err != nil {
+		return addrs, nil
+	}
+	addrs = append(addrs, corev1.NodeAddress{
+		Type:    corev1.NodeHostName,
+		Address: hostname,
+	})
+
 	return addrs, nil
 }
 


### PR DESCRIPTION
virDomainGetHostname [1] recommends passing 0 as the flag.

hostname should be reported for a machine so that server certificate for the kubelet is approved by the
cluster-machine-approver [2]

[1]: https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainGetHostname
[2]: https://github.com/openshift/cluster-machine-approver/pull/10