### PR TITLE
Record update events

### DIFF
--- a/vendor/github.com/openshift/cluster-api/pkg/apis/machine/common/consts.go
+++ b/vendor/github.com/openshift/cluster-api/pkg/apis/machine/common/consts.go
@@ -51,6 +51,13 @@ const (
 	// Example: timeout trying to connect to GCE.
 	CreateMachineError MachineStatusError = "CreateError"
 
+	// There was an error while trying to update a Node that this
+	// Machine represents. This may indicate a transient problem that will be
+	// fixed automatically with time, such as a service outage,
+	//
+	// Example: error updating load balancers
+	UpdateMachineError MachineStatusError = "UpdateError"
+
 	// An error was encountered while trying to delete the Node that this
 	// Machine represents. This could be a transient or terminal error, but
 	// will only be observable if the provider's Machine controller has

--- a/vendor/github.com/openshift/cluster-api/pkg/errors/machines.go
+++ b/vendor/github.com/openshift/cluster-api/pkg/errors/machines.go
@@ -53,6 +53,13 @@ func CreateMachine(msg string, args ...interface{}) *MachineError {
 	}
 }
 
+func UpdateMachine(msg string, args ...interface{}) *MachineError {
+	return &MachineError{
+		Reason:  commonerrors.UpdateMachineError,
+		Message: fmt.Sprintf(msg, args...),
+	}
+}
+
 func DeleteMachine(msg string, args ...interface{}) *MachineError {
 	return &MachineError{
 		Reason:  commonerrors.DeleteMachineError,


### PR DESCRIPTION
In case a load balancer were not updated.
Or, to report a machine configuration is invalid.
Reporting successful machine update operation will also
drops the invalid machine configuration event.

Corresponding openshift cluster-api PR: https://github.com/openshift/cluster-api/pull/14