### PR TITLE
Fetch VM hostname from the DHCP lease

### DIFF
--- a/pkg/cloud/libvirt/client/mock/client_generated.go
+++ b/pkg/cloud/libvirt/client/mock/client_generated.go
@@ -148,3 +148,18 @@ func (mr *MockClientMockRecorder) DeleteVolume(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolume", reflect.TypeOf((*MockClient)(nil).DeleteVolume), name)
 }
+
+// LookupDomainHostnameByDHCPLease mocks base method
+func (m *MockClient) LookupDomainHostnameByDHCPLease(domIPAddress, networkName string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LookupDomainHostnameByDHCPLease", domIPAddress, networkName)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LookupDomainHostnameByDHCPLease indicates an expected call of LookupDomainHostnameByDHCPLease
+func (mr *MockClientMockRecorder) LookupDomainHostnameByDHCPLease(domIPAddress, networkName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookupDomainHostnameByDHCPLease", reflect.TypeOf((*MockClient)(nil).LookupDomainHostnameByDHCPLease), domIPAddress, networkName)
+}


### PR DESCRIPTION
Currently, we tried to fetch hostname from the guest agent, that
does not exist on the RHOS, so it does not the option.

This PR will fetch VM hostname from the DHCP lease by iface IP address.
We already have similar PR and I can close this one in favor of https://github.com/openshift/cluster-api-provider-libvirt/pull/125, but only if we have guarantees that the node name and the VM hostname always will be equal.