### PR TITLE
Copy bridge, loopback and host-local to /opt/cni/bin

### DIFF
--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/manifests/userdata.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/manifests/userdata.go
@@ -32,6 +32,12 @@ kubeadm init --apiserver-bind-port 8443 --token 2iqzqm.85bs0x6miyx1nm7l {{range 
 # Enable networking by default.
 kubectl apply -f https://raw.githubusercontent.com/cloudnativelabs/kube-router/master/daemonset/kubeadm-kuberouter.yaml --kubeconfig /etc/kubernetes/admin.conf
 
+# Binaries expected under /opt/cni/bin are actually under /usr/libexec/cni
+mkdir -p /opt/cni/bin
+pushd /usr/libexec/cni
+cp bridge loopback host-local /opt/cni/bin
+popd
+
 mkdir -p /root/.kube
 cp -i /etc/kubernetes/admin.conf /root/.kube/config
 chown $(id -u):$(id -g) /root/.kube/config


### PR DESCRIPTION
Due to the following complaint:
Warning  FailedCreatePodSandBox  6m                kubelet, 192.168.122.51  Failed create pod sandbox: rpc error: code = Unknown desc = [failed to set up sandbox container "734dfc50315f6041dce9db799855764a14af127d41ec1756b36fede207211d54" network for pod "clusterapi-controllers-9cb7f5b49-ptn2s": NetworkPlugin cni failed to set up pod "clusterapi-controllers-9cb7f5b49-ptn2s_namespace-cb0d1035-44d1-11e9-8b94-0cc47a8055ac" network: failed to find plugin "loopback" in path [/opt/cni/bin], failed to clean up sandbox container "734dfc50315f6041dce9db799855764a14af127d41ec1756b36fede207211d54" network for pod "clusterapi-controllers-9cb7f5b49-ptn2s": NetworkPlugin cni failed to teardown pod "clusterapi-controllers-9cb7f5b49-ptn2s_namespace-cb0d1035-44d1-11e9-8b94-0cc47a8055ac" network: failed to find plugin "bridge" in path [/opt/cni/bin]]