### PR TITLE
HACKING: Wait between scaling up & down clusterapi-manager-controllers

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -63,6 +63,8 @@ image:
 
 ```
 oc scale --replicas 0 deployments/clusterapi-manager-controllers
+# If we scale up immediately after, new images will not be used.
+sleep 5
 oc scale --replicas 1 deployments/clusterapi-manager-controllers
 ```
 


### PR DESCRIPTION
As I found out while testing #128, you need to wait a bit between scaling up and down the `clusterapi-manager-controllers` deployment for the new images to be picked up immediately.