### PR TITLE
Use host-passthrough CPU mode for wokers

### DIFF
--- a/pkg/cloud/libvirt/client/domain.go
+++ b/pkg/cloud/libvirt/client/domain.go
@@ -426,6 +426,8 @@ func domainDefInit(domainDef *libvirtxml.Domain, name string, memory, vcpu int) 
 		return fmt.Errorf("machine does not have an DomainVcpu set")
 	}
 
+	domainDef.CPU.Mode = "host-passthrough"
+
 	//setConsoles(d, &domainDef)
 	//setCmdlineArgs(d, &domainDef)
 	//setFirmware(d, &domainDef)


### PR DESCRIPTION
It makes possible to run KubeVirt workflow on top of the libvirt provider.

Fixes #105 