### PR TITLE
verify staleness of vendored cluster-api-actuator-pkg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,11 @@ push:
 	docker push "$(IMAGE):$(MUTABLE_TAG)"
 
 .PHONY: check
-check: fmt vet lint test ## Check your code
+check: fmt vet lint test check-pkg ## Check your code
+
+.PHONY: check-pkg
+check-pkg:
+	./hack/verify-actuator-pkg.sh
 
 .PHONY: test
 test: # Run unit test

--- a/hack/verify-actuator-pkg.sh
+++ b/hack/verify-actuator-pkg.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+if ! command -v dep 1>/dev/null 2>&1; then
+	curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+fi
+
+if dep check | grep -q cluster-api-actuator-pkg; then
+	exit 1
+fi
+dep ensure -update github.com/openshift/cluster-api-actuator-pkg
+git diff --exit-code


### PR DESCRIPTION
Simple way to verify if we are vendoring latest actuator-pkg. This should be executed as a separate optional CI job.

Combination of https://github.com/openshift/machine-api-operator/pull/248 and https://github.com/openshift/machine-api-operator/pull/259

/hold