### PR TITLE
Drop volumes full paths

### DIFF
--- a/examples/machine-set.yaml
+++ b/examples/machine-set.yaml
@@ -33,7 +33,7 @@ spec:
           ignKey: /var/lib/libvirt/images/worker.ign
           volume:
             poolName: default
-            baseVolumeID: /var/lib/libvirt/images/coreos_base
+            baseVolumeID: coreos_base
           networkInterfaceName: tectonic
           networkInterfaceAddress: 192.168.124.12
           autostart: false

--- a/examples/machine-with-full-paths.yaml
+++ b/examples/machine-with-full-paths.yaml
@@ -18,7 +18,7 @@ spec:
       ignKey: /var/lib/libvirt/images/worker.ign
       volume:
         poolName: default
-        baseVolumeID: /var/lib/libvirt/images/baseVolume
+        baseVolumeID: baseVolume
       networkInterfaceName: actuatorTestNetwork
       networkInterfaceAddress: 192.168.124.0/24
       autostart: false

--- a/examples/machine-with-userdata.yml
+++ b/examples/machine-with-userdata.yml
@@ -21,7 +21,7 @@ spec:
         userDataSecret: libvirt-actuator-user-data-secret
       volume:
         poolName: default
-        baseVolumeID: /var/lib/libvirt/images/fedora_base
+        baseVolumeID: fedora_base
       networkInterfaceName: default
       networkInterfaceAddress: 192.168.122.0/24
       autostart: false

--- a/examples/machine.yaml
+++ b/examples/machine.yaml
@@ -19,7 +19,7 @@ spec:
       ignKey: /var/lib/libvirt/images/worker.ign
       volume:
         poolName: default
-        baseVolumeID: /var/lib/libvirt/images/coreos_base
+        baseVolumeID: coreos_base
       networkInterfaceName: tectonic
       networkInterfaceAddress: 192.168.124.12
       autostart: false

--- a/pkg/cloud/libvirt/actuators/machine/actuator_test.go
+++ b/pkg/cloud/libvirt/actuators/machine/actuator_test.go
@@ -180,7 +180,7 @@ func TestMachineEvents(t *testing.T) {
 			params := ActuatorParams{
 				ClusterClient: fakeclusterclientset.NewSimpleClientset(tc.machine),
 				KubeClient:    kubernetesfake.NewSimpleClientset(),
-				ClientBuilder: func(uri string) (libvirtclient.Client, error) {
+				ClientBuilder: func(uri string, pool string) (libvirtclient.Client, error) {
 					if tc.error == libvirtClientError {
 						return nil, fmt.Errorf(libvirtClientError)
 					}

--- a/pkg/cloud/libvirt/actuators/machine/stubs.go
+++ b/pkg/cloud/libvirt/actuators/machine/stubs.go
@@ -25,7 +25,7 @@ func stubProviderConfig() *providerconfigv1.LibvirtMachineProviderConfig {
 		},
 		Volume: &providerconfigv1.Volume{
 			PoolName:     "default",
-			BaseVolumeID: "/var/lib/libvirt/images/fedora_base",
+			BaseVolumeID: "fedora_base",
 		},
 		NetworkInterfaceName:    "default",
 		NetworkInterfaceAddress: "192.168.124.12/24",

--- a/pkg/cloud/libvirt/client/cloudinit.go
+++ b/pkg/cloud/libvirt/client/cloudinit.go
@@ -19,7 +19,7 @@ import (
 	providerconfigv1 "github.com/openshift/cluster-api-provider-libvirt/pkg/apis/libvirtproviderconfig/v1beta1"
 )
 
-func setCloudInit(domainDef *libvirtxml.Domain, client *libvirtClient, cloudInit *providerconfigv1.CloudInit, kubeClient kubernetes.Interface, machineNamespace, volumeName, poolName, domainName string) error {
+func setCloudInit(domainDef *libvirtxml.Domain, client *libvirtClient, cloudInit *providerconfigv1.CloudInit, kubeClient kubernetes.Interface, machineNamespace, volumeName, domainName string) error {
 
 	// At least user data or ssh access needs to be set to create the cloud init
 	if cloudInit.UserDataSecret == "" && !cloudInit.SSHAccess {
@@ -56,7 +56,7 @@ func setCloudInit(domainDef *libvirtxml.Domain, client *libvirtClient, cloudInit
 	cloudInitDef.UserData = string(userData)
 	cloudInitDef.MetaData = string(metaData)
 	cloudInitDef.Name = cloudInitISOName
-	cloudInitDef.PoolName = poolName
+	cloudInitDef.PoolName = client.poolName
 
 	glog.Infof("cloudInitDef: %+v", cloudInitDef)
 

--- a/pkg/cloud/libvirt/client/domain.go
+++ b/pkg/cloud/libvirt/client/domain.go
@@ -19,10 +19,6 @@ import (
 	"github.com/openshift/cluster-api-provider-libvirt/lib/cidr"
 )
 
-const (
-	baseVolumePath = "/var/lib/libvirt/images/"
-)
-
 // ErrLibVirtConIsNil is returned when the libvirt connection is nil.
 var ErrLibVirtConIsNil = errors.New("the libvirt connection was nil")
 
@@ -265,13 +261,8 @@ func randomWWN(strlen int) string {
 	return oui + string(result)
 }
 
-func setDisks(domainDef *libvirtxml.Domain, virConn *libvirt.Connect, volumeKey string) error {
+func setDisks(domainDef *libvirtxml.Domain, diskVolume *libvirt.StorageVol) error {
 	disk := newDefDisk(0)
-	glog.Info("Looking up storage volume by key")
-	diskVolume, err := virConn.LookupStorageVolByKey(volumeKey)
-	if err != nil {
-		return fmt.Errorf("Can't retrieve volume %s", volumeKey)
-	}
 	glog.Info("Getting disk volume")
 	diskVolumeFile, err := diskVolume.GetPath()
 	if err != nil {

--- a/pkg/cloud/libvirt/client/ignition.go
+++ b/pkg/cloud/libvirt/client/ignition.go
@@ -15,7 +15,7 @@ import (
 	providerconfigv1 "github.com/openshift/cluster-api-provider-libvirt/pkg/apis/libvirtproviderconfig/v1beta1"
 )
 
-func setIgnition(domainDef *libvirtxml.Domain, client *libvirtClient, ignition *providerconfigv1.Ignition, kubeClient kubernetes.Interface, machineNamespace, volumeName, poolName string) error {
+func setIgnition(domainDef *libvirtxml.Domain, client *libvirtClient, ignition *providerconfigv1.Ignition, kubeClient kubernetes.Interface, machineNamespace, volumeName string) error {
 	glog.Info("Creating ignition file")
 	ignitionDef := newIgnitionDef()
 
@@ -33,7 +33,7 @@ func setIgnition(domainDef *libvirtxml.Domain, client *libvirtClient, ignition *
 	}
 
 	ignitionDef.Name = volumeName
-	ignitionDef.PoolName = poolName
+	ignitionDef.PoolName = client.poolName
 	ignitionDef.Content = string(userDataSecret)
 
 	glog.Infof("Ignition: %+v", ignitionDef)

--- a/test/utils/manifests.go
+++ b/test/utils/manifests.go
@@ -16,7 +16,7 @@ func TestingMachineProviderSpec(uri, clusterID string) (machinev1.ProviderSpec, 
 		},
 		Volume: &providerconfigv1.Volume{
 			PoolName:     "default",
-			BaseVolumeID: "/var/lib/libvirt/images/fedora_base",
+			BaseVolumeID: "fedora_base",
 		},
 		NetworkInterfaceName:    "default",
 		NetworkInterfaceAddress: "192.168.124.12/24",
@@ -45,7 +45,7 @@ func MasterMachineProviderSpec(masterUserDataSecret, libvirturi string) (machine
 		},
 		Volume: &providerconfigv1.Volume{
 			PoolName:     "default",
-			BaseVolumeID: "/var/lib/libvirt/images/fedora_base",
+			BaseVolumeID: "fedora_base",
 		},
 		NetworkInterfaceName:    "default",
 		NetworkInterfaceAddress: "192.168.122.0/24",


### PR DESCRIPTION
The path of the storage volume is and should be determined by the containing storage pool and hence we should not associate and assume the path of the volume.

Without this change, it is not possible for user to specify alternative location for storage volumes to Openshift Installer.

**WARNING:** 

 * This will also require a change in the Openshift Installer as that still passess the volume path instead of name to the actuator.

 * I've not testing this yet, only built successfully.

----
This is a revision/rebase of https://github.com/openshift/cluster-api-provider-libvirt/pull/45