### PR TITLE
facility field removed in favor of facilities

### DIFF
--- a/hack/prebuild/main.tf
+++ b/hack/prebuild/main.tf
@@ -6,7 +6,7 @@ resource "packet_ssh_key" "key" {
 resource "packet_device" "libvirt" {
   hostname         = "libvirt-${var.id}"
   plan             = "baremetal_1"
-  facility         = "sjc1"
+  facilities       = ["sjc1"]
   operating_system = "centos_7"
   billing_cycle    = "hourly"
   project_id       = "${var.packet_project_id}"


### PR DESCRIPTION
```
Error: packet_device.libvirt: "facilities": required field is not set

Error: packet_device.libvirt: "facility": [REMOVED] Use the "facilities" array instead, i.e. change
  facility = "ewr1"
to
  facilities = ["ewr1"]
```