### PR TITLE
OWNERS: Add CRC team members

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,13 @@
 approvers:
+  - cfergeau
   - enxebre
   - frobware
+  - gbraad
   - ingvagabund
   - paulfantom
+  - praveenkumar
   - spangenberg
   - bison
   - vikaschoudhary16
   - michaelgugino
+  - zeenix


### PR DESCRIPTION
This is to extend the ownership to CRC team.