### PR TITLE
Remove workaround for old libvirt bug

### DIFF
--- a/pkg/cloud/libvirt/client/client.go
+++ b/pkg/cloud/libvirt/client/client.go
@@ -520,14 +520,6 @@ func (client *libvirtClient) DeleteVolume(name string) error {
 		return volPool.Refresh(0)
 	})
 
-	// Workaround for redhat#1293804
-	// https://bugzilla.redhat.com/show_bug.cgi?id=1293804#c12
-	// Does not solve the problem but it makes it happen less often.
-	_, err = volume.GetXMLDesc(0)
-	if err != nil {
-		return fmt.Errorf("Can't retrieve volume %s XML desc: %s", name, err)
-	}
-
 	err = volume.Delete(0)
 	if err != nil {
 		return fmt.Errorf("Can't delete volume %s: %s", name, err)


### PR DESCRIPTION
The bug was fixed in libvirt 1.3.3 which was released 3 years ago.

Supported fedora releases ship a much newer version
EL7.3 already had libvirt 2.0.0
Debian stable has libvirt 3.0.0
Ubuntu 18.04 LTS has libvirt 4.0.0