### PR TITLE
Drop the error when the libvirt VM still does not have nic's

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -411,7 +411,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3247b963f680c21d5a7158bb4720a20b39f32eeba8e09a5bb62aebfa13d68146"
+  digest = "1:3c9fe8f4fd2b974bbd9c7bdea10395833e6ab00856bd5875a22b5d9fea72d127"
   name = "github.com/openshift/cluster-api-actuator-pkg"
   packages = [
     "pkg/e2e/framework",
@@ -419,7 +419,7 @@
     "pkg/types",
   ]
   pruneopts = "T"
-  revision = "7628df78fb4c697fd8244495271b45af95a2184a"
+  revision = "42228d06a2ca38d6f0f007a1f9e4ac7758d4ff45"
 
 [[projects]]
   branch = "master"
@@ -1131,6 +1131,7 @@
     "github.com/openshift/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1/fake",
     "github.com/openshift/cluster-api/pkg/client/clientset_generated/clientset/typed/machine/v1beta1",
     "github.com/openshift/cluster-api/pkg/client/clientset_generated/clientset/typed/machine/v1beta1/fake",
+    "github.com/openshift/cluster-api/pkg/controller/error",
     "github.com/openshift/cluster-api/pkg/controller/machine",
     "github.com/openshift/cluster-api/pkg/errors",
     "github.com/spf13/cobra",

--- a/pkg/cloud/libvirt/actuators/machine/actuator.go
+++ b/pkg/cloud/libvirt/actuators/machine/actuator.go
@@ -16,6 +16,7 @@ package machine
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/golang/glog"
 
@@ -23,6 +24,7 @@ import (
 
 	providerconfigv1 "github.com/openshift/cluster-api-provider-libvirt/pkg/apis/libvirtproviderconfig/v1beta1"
 	libvirtclient "github.com/openshift/cluster-api-provider-libvirt/pkg/cloud/libvirt/client"
+	controllererrors "github.com/openshift/cluster-api/pkg/controller/error"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -460,6 +462,11 @@ func NodeAddresses(client libvirtclient.Client, dom *libvirt.Domain, networkInte
 	ifaces, err := dom.ListAllInterfaceAddresses(ifaceSource)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(ifaces) == 0 {
+		glog.Infof("The domain does not have any network interfaces")
+		return nil, &controllererrors.RequeueAfterError{RequeueAfter: time.Second}
 	}
 
 	for _, iface := range ifaces {


### PR DESCRIPTION
Possible the situation when the actuator command create or update of the VM state to the running state succeeded, but the VM still does not have any interfaces, in this case, it can take a lot of time before the controller will update the machine status with the IP and hostname details that prevent from the auto-approver to approve the certificate.