### PR TITLE
Add internal DNS address type under the machine status

### DIFF
--- a/pkg/cloud/libvirt/actuators/machine/actuator.go
+++ b/pkg/cloud/libvirt/actuators/machine/actuator.go
@@ -479,6 +479,11 @@ func NodeAddresses(client libvirtclient.Client, dom *libvirt.Domain, networkInte
 					Type:    corev1.NodeHostName,
 					Address: hostname,
 				})
+
+				addrs = append(addrs, corev1.NodeAddress{
+					Type:    corev1.NodeInternalDNS,
+					Address: hostname,
+				})
 			}
 		}
 	}


### PR DESCRIPTION
Machine approver approves the node bootstrap CSR by internal DNS, so
if the field is missing auto-approving will fail and a new node will not
join the cluster.