### PR TITLE
Cache leases IP's and do not use them on the machine creation

### DIFF
--- a/pkg/cloud/libvirt/actuators/machine/actuator_test.go
+++ b/pkg/cloud/libvirt/actuators/machine/actuator_test.go
@@ -198,6 +198,7 @@ func TestMachineEvents(t *testing.T) {
 			mockLibvirtClient.EXPECT().DeleteVolume(gomock.Any()).Return(tc.deleteVolumeErr).AnyTimes()
 			mockLibvirtClient.EXPECT().CreateDomain(gomock.Any()).Return(tc.createDomainErr).AnyTimes()
 			mockLibvirtClient.EXPECT().DeleteDomain(gomock.Any()).Return(tc.deleteDomainErr).AnyTimes()
+			mockLibvirtClient.EXPECT().GetDHCPLeasesByNetwork(gomock.Any())
 			mockLibvirtClient.EXPECT().LookupDomainByName(gomock.Any()).Return(tc.lookupDomainOutput, tc.lookupDomainErr).AnyTimes()
 			mockLibvirtClient.EXPECT().DomainExists(gomock.Any()).Return(tc.domainExists, tc.domainExistsErr).AnyTimes()
 

--- a/pkg/cloud/libvirt/client/mock/client_generated.go
+++ b/pkg/cloud/libvirt/client/mock/client_generated.go
@@ -149,6 +149,21 @@ func (mr *MockClientMockRecorder) DeleteVolume(name interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolume", reflect.TypeOf((*MockClient)(nil).DeleteVolume), name)
 }
 
+// GetDHCPLeasesByNetwork mocks base method
+func (m *MockClient) GetDHCPLeasesByNetwork(networkName string) ([]libvirt_go.NetworkDHCPLease, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDHCPLeasesByNetwork", networkName)
+	ret0, _ := ret[0].([]libvirt_go.NetworkDHCPLease)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDHCPLeasesByNetwork indicates an expected call of GetDHCPLeasesByNetwork
+func (mr *MockClientMockRecorder) GetDHCPLeasesByNetwork(networkName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDHCPLeasesByNetwork", reflect.TypeOf((*MockClient)(nil).GetDHCPLeasesByNetwork), networkName)
+}
+
 // LookupDomainHostnameByDHCPLease mocks base method
 func (m *MockClient) LookupDomainHostnameByDHCPLease(domIPAddress, networkName string) (string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Workers got IP's from DHCP, by default first machine will get IP x.x.x.51,
the second x.x.x.52... But if machine-controllers deployment restarted, it
will start again from x.x.x.51 for new machines. To avoid it, we will cache
IP leases on the first `Create()` call and will generate new IP until we get
IP that does not exist under the cache.

Fixes #134