### PR TITLE
Support config drive for ignition config on PowerPC

### DIFF
--- a/pkg/cloud/libvirt/client/client.go
+++ b/pkg/cloud/libvirt/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/xml"
 	"fmt"
+	"strings"
 
 	"github.com/golang/glog"
 	libvirt "github.com/libvirt/libvirt-go"
@@ -198,9 +199,10 @@ func (client *libvirtClient) CreateDomain(input CreateDomainInput) error {
 		return fmt.Errorf("Error retrieving host architecture: %s", err)
 	}
 	// Both "s390" and "s390x" are linux kernel architectures for Linux on IBM z Systems, and they are for 31-bit and 64-bit respectively.
-	if arch == "s390x" || arch == "s390" {
+	// PowerPC architectures require this support as well
+	if strings.HasPrefix(arch, "s390") || strings.HasPrefix(arch, "ppc64") {
 		if input.Ignition != nil {
-			if err := setIgnitionForS390X(&domainDef, client, input.Ignition, input.KubeClient, input.MachineNamespace, input.IgnitionVolumeName); err != nil {
+			if err := setIgnitionWithConfigDrive(&domainDef, client, input.Ignition, input.KubeClient, input.MachineNamespace, input.IgnitionVolumeName); err != nil {
 				return err
 			}
 		}

--- a/pkg/cloud/libvirt/client/configdrive_ignition.go
+++ b/pkg/cloud/libvirt/client/configdrive_ignition.go
@@ -17,8 +17,9 @@ import (
 
 var execCommand = exec.Command
 
-func setIgnitionForS390X(domainDef *libvirtxml.Domain, client *libvirtClient, ignition *providerconfigv1.Ignition, kubeClient kubernetes.Interface, machineNamespace, volumeName string) error {
-	glog.Infof("Creating ignition file for s390x")
+// Currently used for s390 and PowerPC arches
+func setIgnitionWithConfigDrive(domainDef *libvirtxml.Domain, client *libvirtClient, ignition *providerconfigv1.Ignition, kubeClient kubernetes.Interface, machineNamespace, volumeName string) error {
+	glog.Infof("Creating ignition file with config drive")
 	ignitionDef := newIgnitionDef()
 
 	if ignition.UserDataSecret == "" {
@@ -55,7 +56,7 @@ func setIgnitionForS390X(domainDef *libvirtxml.Domain, client *libvirtClient, ig
 		return fmt.Errorf("Error create and upload iso file: %s", err)
 	}
 
-	glog.Infof("Calling newDiskForConfigDrive for coreos_ignition on s390x ")
+	glog.Infof("Calling newDiskForConfigDrive for coreos_ignition ")
 	disk, err := newDiskForConfigDrive(client.connection, ignitionVolumeName)
 	if err != nil {
 		return err
@@ -105,7 +106,7 @@ func newDiskForConfigDrive(virConn *libvirt.Connect, volumeKey string) (libvirtx
 	disk := libvirtxml.DomainDisk{
 		Device: "cdrom",
 		Target: &libvirtxml.DomainDiskTarget{
-			// s390 platform doesn't support IDE controller, it shoule be virtio controller
+			// s390 and ppc platforms doesn't support IDE controller, it shoule be virtio controller
 			Dev: "vdb",
 			Bus: "scsi",
 		},


### PR DESCRIPTION
Following up on #182, the same mechanism is needed for
PowerPC systems for an Openshift baremetal IPI installation
because PowerPC does not support fw_cfg.

Also don't use Spice for the graphics as it is not supported in
PowerPC.

Contributors: @mtarsel