### PR TITLE
Do not use Spice graphics for PowerPC systems

### DIFF
--- a/pkg/cloud/libvirt/client/domain.go
+++ b/pkg/cloud/libvirt/client/domain.go
@@ -108,7 +108,8 @@ func newDevicesDef(virConn *libvirt.Connect) *libvirtxml.DomainDeviceList {
 	}
 	// Both "s390" and "s390x" are linux kernel architectures for Linux on IBM z Systems, and they are for 31-bit and 64-bit respectively.
 	// Graphics/Spice isn't supported on s390/s390x platform.
-	if arch != "s390x" && arch != "s390" {
+	// Same case for PowerPC systems as well
+	if !strings.HasPrefix(arch, "s390") && !strings.HasPrefix(arch, "ppc64") {
 		domainList.Graphics = []libvirtxml.DomainGraphic{
 			{
 				Spice: &libvirtxml.DomainGraphicSpice{


### PR DESCRIPTION
PowerPC systems do not support spice graphics, same as s390x. Do not set
the graphics to spice on PowerPC.