### PR TITLE
BUG 1855288: fix memory leak that leads to unresponsive libvirt URI

### DIFF
--- a/pkg/cloud/libvirt/client/client.go
+++ b/pkg/cloud/libvirt/client/client.go
@@ -155,9 +155,14 @@ func NewClient(URI string, poolName string) (Client, error) {
 
 // Close closes the client's libvirt connection.
 func (client *libvirtClient) Close() error {
-	glog.Infof("Closing libvirt connection: %p", client.connection)
+	glog.Infof("Freeing the client pool")
+	err := client.pool.Free()
+	if err != nil {
+		glog.Infof("Error freeing the client pool: %v", err)
+	}
 
-	_, err := client.connection.Close()
+	glog.Infof("Closing libvirt connection: %p", client.connection)
+	_, err = client.connection.Close()
 	if err != nil {
 		glog.Infof("Error closing libvirt connection: %v", err)
 	}
@@ -558,6 +563,7 @@ func (client *libvirtClient) GetDHCPLeasesByNetwork(networkName string) ([]libvi
 		glog.Errorf("Failed to fetch network %s from the libvirt", networkName)
 		return nil, err
 	}
+	defer network.Free()
 
 	return network.GetDHCPLeases()
 }

--- a/pkg/cloud/libvirt/client/client.go
+++ b/pkg/cloud/libvirt/client/client.go
@@ -196,6 +196,7 @@ func (client *libvirtClient) CreateDomain(ctx context.Context, input CreateDomai
 	if err != nil {
 		return fmt.Errorf("can't retrieve volume %s for pool %s: %v", input.VolumeName, client.poolName, err)
 	}
+	defer diskVolume.Free()
 	if err := setDisks(&domainDef, diskVolume); err != nil {
 		return fmt.Errorf("Failed to setDisks: %s", err)
 	}
@@ -216,6 +217,7 @@ func (client *libvirtClient) CreateDomain(ctx context.Context, input CreateDomai
 		if err != nil {
 			return fmt.Errorf("error getting ignition volume: %v", err)
 		}
+		defer ignVolume.Free()
 		ignVolumePath, err := ignVolume.GetPath()
 		if err != nil {
 			return fmt.Errorf("error getting ignition volume path: %v", err)
@@ -387,6 +389,7 @@ func (client *libvirtClient) CreateVolume(input CreateVolumeInput) error {
 
 	volume, err := client.getVolume(input.VolumeName)
 	if err == nil {
+		volume.Free()
 		return fmt.Errorf("storage volume '%s' already exists", input.VolumeName)
 	}
 
@@ -419,6 +422,7 @@ func (client *libvirtClient) CreateVolume(input CreateVolumeInput) error {
 		if err != nil {
 			return fmt.Errorf("Can't retrieve volume %s", input.BaseVolumeName)
 		}
+		defer baseVolume.Free()
 		var baseVolumeInfo *libvirt.StorageVolInfo
 		baseVolumeInfo, err = baseVolume.GetInfo()
 		if err != nil {

--- a/pkg/cloud/libvirt/client/client.go
+++ b/pkg/cloud/libvirt/client/client.go
@@ -162,9 +162,12 @@ func (client *libvirtClient) Close() error {
 	}
 
 	glog.Infof("Closing libvirt connection: %p", client.connection)
-	_, err = client.connection.Close()
+	remainingRefs, err := client.connection.Close()
 	if err != nil {
 		glog.Infof("Error closing libvirt connection: %v", err)
+	}
+	if remainingRefs != 0 {
+		glog.Warningf("libvirt connection %p was not closed, some objects are still holding references to it", client.connection)
 	}
 
 	return err


### PR DESCRIPTION
The libvirt C library will maintain open connections against the URI based on an internal reference counting scheme.  This pull request adds calls to Free() for a storage pool and a network object which otherwise cause unused connections to linger and stack, causing an unresponsive URI at scale.