### PR TITLE
actuator: cleanup cloudinit and ignition volume on error, bump golang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.16 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-api-provider-libvirt
 COPY . .
 RUN go build -o machine-controller-manager ./cmd/manager
 
-FROM docker.io/centos:7
+FROM docker.io/fedora:35
 RUN INSTALL_PKGS=" \
       libvirt-libs openssh-clients genisoimage \
       " && \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,11 +1,11 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.9 AS builder
 RUN yum install -y libvirt-devel
 
 WORKDIR /go/src/github.com/openshift/cluster-api-provider-libvirt
 COPY . .
 RUN go build -o machine-controller-manager ./cmd/manager
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.ci.openshift.org/ocp/4.9:base
 RUN INSTALL_PKGS=" \
       libvirt-libs openssh-clients genisoimage \
       " && \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PROJECT     ?= cluster-api-provider-libvirt
 ORG_PATH    ?= github.com/openshift
 REPO_PATH   ?= $(ORG_PATH)/$(PROJECT)
 CLUSTER_API ?= github.com/openshift/cluster-api
-IMAGE        = origin-libvirt-machine-controllers
+IMAGE       ?= origin-libvirt-machine-controllers
 
 ifeq ($(DBG),1)
 GOGCFLAGS ?= -gcflags=all="-N -l"
@@ -22,7 +22,7 @@ ifeq ($(NO_DOCKER), 1)
   IMAGE_BUILD_CMD = imagebuilder
   CGO_ENABLED = 1
 else
-  DOCKER_CMD := $(CONTAINER_RUNTIME) run --rm -e CGO_ENABLED=1 -v "$(PWD):/go/src/$(REPO_PATH):Z" -w "/go/src/$(REPO_PATH)" openshift/origin-release:golang-1.13
+  DOCKER_CMD := $(CONTAINER_RUNTIME) run --rm -e CGO_ENABLED=1 -v "$(PWD):/go/src/$(REPO_PATH):Z" -w "/go/src/$(REPO_PATH)" registry.ci.openshift.org/openshift/release:golang-1.16
   IMAGE_BUILD_CMD = $(CONTAINER_RUNTIME) build
 endif
 

--- a/hack/go-fmt.sh
+++ b/hack/go-fmt.sh
@@ -11,6 +11,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/cluster-api-provider-libvirt:z" \
     --workdir /go/src/github.com/openshift/cluster-api-provider-libvirt \
-    openshift/origin-release:golang-1.13 \
+    registry.ci.openshift.org/openshift/release:golang-1.16 \
     ./hack/go-fmt.sh "${@}"
 fi

--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -10,6 +10,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/cluster-api-provider-libvirt:z" \
     --workdir /go/src/github.com/openshift/cluster-api-provider-libvirt \
-    openshift/origin-release:golang-1.13 \
+    registry.ci.openshift.org/openshift/release:golang-1.16 \
     ./hack/go-lint.sh "${@}"
 fi

--- a/hack/go-vet.sh
+++ b/hack/go-vet.sh
@@ -9,6 +9,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/cluster-api-provider-libvirt:z" \
     --workdir /go/src/github.com/openshift/cluster-api-provider-libvirt \
-    openshift/origin-release:golang-1.13 \
+    registry.ci.openshift.org/openshift/release:golang-1.16 \
     ./hack/go-vet.sh "${@}"
 fi;

--- a/pkg/cloud/libvirt/actuators/machine/actuator.go
+++ b/pkg/cloud/libvirt/actuators/machine/actuator.go
@@ -281,8 +281,14 @@ func (a *Actuator) createVolumeAndDomain(ctx context.Context, machine *machinev1
 	}); err != nil {
 		// Clean up the created volume if domain creation fails,
 		// otherwise subsequent runs will fail.
-		if err := client.DeleteVolume(domainName); err != nil {
+		if err := client.DeleteVolume(domainName); err != nil && err != libvirtclient.ErrVolumeNotFound {
 			glog.Errorf("Error cleaning up volume: %v", err)
+		}
+		if err := client.DeleteVolume(cloudInitVolumeName(domainName)); err != nil && err != libvirtclient.ErrVolumeNotFound {
+			glog.Errorf("Error cleaning up cloud-init volume: %v", err)
+		}
+		if err := client.DeleteVolume(ignitionVolumeName(domainName)); err != nil && err != libvirtclient.ErrVolumeNotFound {
+			glog.Errorf("Error cleaning up ignition volume: %v", err)
 		}
 
 		return nil, a.handleMachineError(machine, apierrors.CreateMachine("error creating domain %v", err), createEventAction)


### PR DESCRIPTION
I kept getting `storage volume 'test1-kbpwl-worker-0-shxhm.ignition' exists already` errors on recent installs.

This PR cleans up the cloud-init and ignition volumes on error. Additionally, it bumps golang to 1.16. 