### PR TITLE
README: Update libvirt configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,42 +8,13 @@ This provider runs as a machine-controller deployed by the
 
 ## Allowing the actuator to connect to the libvirt daemon running on the host machine:
 
-Edit `/etc/libvirt/libvirtd.conf` to set:
+Libvirt needs to be configured to accept TCP connections as described in the [installer documentation](https://github.com/openshift/installer/tree/master/docs/dev/libvirt#configure-libvirt-to-accept-tcp-connections).
 
-```
-listen_tls = 0
-listen_tcp = 1
-auth_tcp="none"
-tcp_port = "16509"
-```
-
-Edit `/etc/systemd/system/libvirt-bin.service` to set:
-
-```
-/usr/sbin/libvirtd -l
-```
-
-Then:
-
-```sh
-systemctl restart libvirtd
-```
-
-Allow incoming connections:
-
-```sh
-iptables -I INPUT -p tcp --dport 16509 -j ACCEPT -m comment --comment "Allow insecure libvirt clients"
-```
-
-Verify you can connect through your host private ip:
+You can verify that you can connect through your host private ip with:
 
 ```sh
 virsh -c qemu+tcp://host_private_ip/system
 ```
-
-## Run it with the installer
-Before running the installer make sure you set libvirt to use the host private ip uri above:
-https://github.com/openshift/installer/blob/master/examples/tectonic.libvirt.yaml#L14
 
 ## Video demo
 https://youtu.be/urvXXfdfzVc


### PR DESCRIPTION
These instructions are outdated on systems using socket-activated
libvirt, and one of the link is dead. This removes most of these
instructions and replaces them with a link to the installer libvirt
documentation which is up to date.

This fixes https://github.com/openshift/cluster-api-provider-libvirt/issues/106