### PR TITLE
Set minimum golang version to 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/cluster-api-provider-libvirt
 
-go 1.14
+go 1.16
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
To comply with other providers, we set the minimum golang version to 1.16.