### PR TITLE
client/domain: Remove spice as domain grahics

### DIFF
--- a/pkg/cloud/libvirt/client/domain.go
+++ b/pkg/cloud/libvirt/client/domain.go
@@ -102,19 +102,12 @@ func newDevicesDef(virConn *libvirt.Connect) *libvirtxml.DomainDeviceList {
 		},
 	}
 
-	arch, err := getHostArchitecture(virConn)
-	if err != nil {
-		glog.Errorf("Error retrieving host architecture: %s", err)
-	}
-	// Currently SPICE is supported on x86_64 and aarch64. But it is only enabled in RHEL qemu for x86_64.
-	if arch == "x86_64" {
-		domainList.Graphics = []libvirtxml.DomainGraphic{
-			{
-				Spice: &libvirtxml.DomainGraphicSpice{
-					AutoPort: "yes",
-				},
+	domainList.Graphics = []libvirtxml.DomainGraphic{
+		{
+			VNC: &libvirtxml.DomainGraphicVNC{
+				AutoPort: "yes",
 			},
-		}
+		},
 	}
 
 	return &domainList


### PR DESCRIPTION
On RHEL-9 host spice is no longer supported and recomment to use `VNC` for remote console.

- https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/considerations_in_adopting_rhel_9/assembly_virtualization_considerations-in-adopting-rhel-9#ref_changes-to-spice_assembly_virtualization