### PR TITLE
Add workaround for SLOF regression

### DIFF
--- a/pkg/cloud/libvirt/client/domain.go
+++ b/pkg/cloud/libvirt/client/domain.go
@@ -35,7 +35,7 @@ type pendingMapping struct {
 	network  *libvirt.Network
 }
 
-func newDomainDef(virConn *libvirt.Connect) libvirtxml.Domain {
+func newDomainDef() libvirtxml.Domain {
 	domainDef := libvirtxml.Domain{
 		OS: &libvirtxml.DomainOS{
 			Type: &libvirtxml.DomainOSType{
@@ -51,7 +51,7 @@ func newDomainDef(virConn *libvirt.Connect) libvirtxml.Domain {
 			Value:     1,
 		},
 		CPU:     &libvirtxml.DomainCPU{},
-		Devices: newDevicesDef(virConn),
+		Devices: newDevicesDef(),
 		Features: &libvirtxml.DomainFeatureList{
 			PAE:  &libvirtxml.DomainFeature{},
 			ACPI: &libvirtxml.DomainFeature{},
@@ -68,7 +68,7 @@ func newDomainDef(virConn *libvirt.Connect) libvirtxml.Domain {
 	return domainDef
 }
 
-func newDevicesDef(virConn *libvirt.Connect) *libvirtxml.DomainDeviceList {
+func newDevicesDef() *libvirtxml.DomainDeviceList {
 	domainList := libvirtxml.DomainDeviceList{
 		Channels: []libvirtxml.DomainChannel{
 			{
@@ -173,7 +173,7 @@ func getCanonicalMachineName(caps libvirtxml.Caps, arch string, virttype string,
 }
 
 func newDomainDefForConnection(virConn *libvirt.Connect) (libvirtxml.Domain, error) {
-	d := newDomainDef(virConn)
+	d := newDomainDef()
 
 	arch, err := getHostArchitecture(virConn)
 	if err != nil {

--- a/pkg/cloud/libvirt/client/domain.go
+++ b/pkg/cloud/libvirt/client/domain.go
@@ -69,8 +69,6 @@ func newDomainDef(virConn *libvirt.Connect) libvirtxml.Domain {
 }
 
 func newDevicesDef(virConn *libvirt.Connect) *libvirtxml.DomainDeviceList {
-	var serialPort uint
-
 	domainList := libvirtxml.DomainDeviceList{
 		Channels: []libvirtxml.DomainChannel{
 			{
@@ -93,10 +91,6 @@ func newDevicesDef(virConn *libvirt.Connect) *libvirtxml.DomainDeviceList {
 			{
 				Source: &libvirtxml.DomainChardevSource{
 					Pty: &libvirtxml.DomainChardevSourcePty{},
-				},
-				Target: &libvirtxml.DomainConsoleTarget{
-					Type: "virtio",
-					Port: &serialPort,
 				},
 			},
 		},


### PR DESCRIPTION
A SLOF regression in rhel 8.6 prevents OpenShift libvirt worker nodes from booting.
It's easy to workaround if the VM has a serial (non-virtio) device, so this PR tries to add one.