### PR TITLE
"OCPBUGS-19927: libvirt: Don't force use of virtio console"

### DIFF
--- a/pkg/cloud/libvirt/client/domain.go
+++ b/pkg/cloud/libvirt/client/domain.go
@@ -69,8 +69,6 @@ func newDomainDef(virConn *libvirt.Connect) libvirtxml.Domain {
 }
 
 func newDevicesDef(virConn *libvirt.Connect) *libvirtxml.DomainDeviceList {
-	var serialPort uint
-
 	domainList := libvirtxml.DomainDeviceList{
 		Channels: []libvirtxml.DomainChannel{
 			{
@@ -93,10 +91,6 @@ func newDevicesDef(virConn *libvirt.Connect) *libvirtxml.DomainDeviceList {
 			{
 				Source: &libvirtxml.DomainChardevSource{
 					Pty: &libvirtxml.DomainChardevSourcePty{},
-				},
-				Target: &libvirtxml.DomainConsoleTarget{
-					Type: "virtio",
-					Port: &serialPort,
 				},
 			},
 		},


### PR DESCRIPTION
When adding a console to libvirt XML definition, it's a virtio-console
which is added. This triggered an unrelated regression on ppc64le
https://issues.redhat.com/browse/OCPBUGS-17476

This commit lets libvirt uses its preferred device for the console
depending on the platform. On ppc64le, this should correspond to spapr
devices.

This should workaround https://issues.redhat.com/browse/OCPBUGS-17476