### PR TITLE
OCPBUGS-26045: Replace genisoimage with xorriso in 4.15 to allow rhel9 bump

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -7,7 +7,7 @@ RUN go build -o machine-controller-manager ./cmd/manager
 
 FROM registry.ci.openshift.org/ocp/4.15:base
 RUN INSTALL_PKGS=" \
-      libvirt-libs openssh-clients genisoimage \
+      libvirt-libs openssh-clients xorriso \
       " && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \


### PR DESCRIPTION
Test build here: [ose-libvirt-machine-controllers-container-v4.15.0-202311281120.p0.g2b03919.assembly.test](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2797290)

Ref. https://issues.redhat.com/browse/ART-8361