### PR TITLE
Add OKD Dockerfile

### DIFF
--- a/Dockerfile.okd
+++ b/Dockerfile.okd
@@ -1,0 +1,16 @@
+FROM registry.ci.openshift.org/ocp/4.20:base
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS builder
+RUN yum install -y libvirt-devel
+
+WORKDIR /go/src/github.com/openshift/cluster-api-provider-libvirt
+COPY . .
+RUN go build -o machine-controller-manager ./cmd/manager
+
+FROM registry.ci.openshift.org/ocp/4.20:base
+RUN INSTALL_PKGS=" \
+      libvirt-libs openssh-clients xorriso \
+      " && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+COPY --from=builder /go/src/github.com/openshift/cluster-api-provider-libvirt/machine-controller-manager /


### PR DESCRIPTION
Needed for OKD builds. Test build: [ose-libvirt-machine-controllers-container-v4.20.0-202510240938.p2.gef4c372.assembly.test.el9](https://okd-build-history-okd-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/build?nvr=ose-libvirt-machine-controllers-container-v4.20.0-202510240938.p2.gef4c372.assembly.test.el9&outcome=success&type=image)