### PR TITLE
CNF-23050: Migrate away from deprecated ioutil

### DIFF
--- a/pkg/cloud/libvirt/client/cloudinit.go
+++ b/pkg/cloud/libvirt/client/cloudinit.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -144,21 +143,21 @@ func (ci *defCloudInit) createISO() (string, error) {
 // object
 func (ci *defCloudInit) createFiles() (string, error) {
 	glog.Info("Creating ISO contents")
-	tmpDir, err := ioutil.TempDir("", "cloudinit")
+	tmpDir, err := os.MkdirTemp("", "cloudinit")
 	if err != nil {
 		return "", fmt.Errorf("Cannot create tmp directory for cloudinit ISO generation: %s",
 			err)
 	}
 	// user-data
-	if err = ioutil.WriteFile(filepath.Join(tmpDir, userDataFileName), []byte(ci.UserData), os.ModePerm); err != nil {
+	if err = os.WriteFile(filepath.Join(tmpDir, userDataFileName), []byte(ci.UserData), os.ModePerm); err != nil {
 		return "", fmt.Errorf("Error while writing user-data to file: %s", err)
 	}
 	// meta-data
-	if err = ioutil.WriteFile(filepath.Join(tmpDir, metaDataFileName), []byte(ci.MetaData), os.ModePerm); err != nil {
+	if err = os.WriteFile(filepath.Join(tmpDir, metaDataFileName), []byte(ci.MetaData), os.ModePerm); err != nil {
 		return "", fmt.Errorf("Error while writing meta-data to file: %s", err)
 	}
 	// network-config
-	if err = ioutil.WriteFile(filepath.Join(tmpDir, networkConfigFileName), []byte(ci.NetworkConfig), os.ModePerm); err != nil {
+	if err = os.WriteFile(filepath.Join(tmpDir, networkConfigFileName), []byte(ci.NetworkConfig), os.ModePerm); err != nil {
 		return "", fmt.Errorf("Error while writing network-config to file: %s", err)
 	}
 

--- a/pkg/cloud/libvirt/client/ignition.go
+++ b/pkg/cloud/libvirt/client/ignition.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -100,7 +99,7 @@ func (ign *defIgnition) createAndUpload(client *libvirtClient) (string, error) {
 // Dumps the Ignition object to a temporary ignition file
 func (ign *defIgnition) createFile() (string, error) {
 	glog.Info("Creating Ignition temporary file")
-	tempFile, err := ioutil.TempFile("", ign.Name)
+	tempFile, err := os.CreateTemp("", ign.Name)
 	if err != nil {
 		return "", fmt.Errorf("Cannot create tmp file for Ignition: %s",
 			err)


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52

**Migration from deprecated `ioutil` functions:**

* Replaced `ioutil.TempDir` with `os.MkdirTemp` and `ioutil.WriteFile` with `os.WriteFile` in the `createFiles` method of `cloudinit.go` to create temporary directories and write files. [[1]](diffhunk://#diff-59897c845eb91881054d7cc9f8ebb62b8f4297b239dc9d224a30738a8bc12766L8) [[2]](diffhunk://#diff-59897c845eb91881054d7cc9f8ebb62b8f4297b239dc9d224a30738a8bc12766L147-R160)
* Replaced `ioutil.TempFile` with `os.CreateTemp` in the `createFile` method of `ignition.go` for creating temporary files. [[1]](diffhunk://#diff-71618d5cc49d39335e22ce9a99b0c99b46f6accc437d81c326cbd5413dfbef21L8) [[2]](diffhunk://#diff-71618d5cc49d39335e22ce9a99b0c99b46f6accc437d81c326cbd5413dfbef21L103-R102)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to remove deprecated libraries and improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->