### PR TITLE
libvirt: omit PAE/ACPI/APIC features for s390x domains

### DIFF
--- a/pkg/cloud/libvirt/client/domain.go
+++ b/pkg/cloud/libvirt/client/domain.go
@@ -68,6 +68,20 @@ func newDomainDef() libvirtxml.Domain {
 	return domainDef
 }
 
+// clearX86OnlyDomainFeaturesForArch removes PAE/ACPI/APIC features for
+// architectures where libvirt does not support them. newDomainDef() always
+// sets x86-style features; s390x guests use virtio-ccw / SCLP, and machine
+// types such as s390-ccw-virtio-rhel9.6.0 on RHEL 9 + QEMU 9 reject
+// <acpi/> with virError 67 (does not support ACPI).
+func clearX86OnlyDomainFeaturesForArch(d *libvirtxml.Domain) {
+	if d == nil || d.OS == nil || d.OS.Type == nil {
+		return
+	}
+	if strings.HasPrefix(d.OS.Type.Arch, "s390") {
+		d.Features = nil
+	}
+}
+
 func newDevicesDef() *libvirtxml.DomainDeviceList {
 	domainList := libvirtxml.DomainDeviceList{
 		Channels: []libvirtxml.DomainChannel{
@@ -201,6 +215,9 @@ func newDomainDefForConnection(virConn *libvirt.Connect) (libvirtxml.Domain, err
 		return d, err
 	}
 	d.OS.Type.Machine = canonicalmachine
+
+	clearX86OnlyDomainFeaturesForArch(&d)
+
 	return d, nil
 }
 

--- a/pkg/cloud/libvirt/client/domain_test.go
+++ b/pkg/cloud/libvirt/client/domain_test.go
@@ -7,6 +7,28 @@ import (
 	libvirtxml "github.com/libvirt/libvirt-go-xml"
 )
 
+func TestClearX86OnlyDomainFeaturesForArchS390x(t *testing.T) {
+	d := newDomainDef()
+	if d.Features == nil || d.Features.ACPI == nil {
+		t.Fatal("newDomainDef should set x86-style features including ACPI")
+	}
+	d.OS.Type.Arch = "s390x"
+	clearX86OnlyDomainFeaturesForArch(&d)
+	if d.Features != nil {
+		t.Fatalf("s390x: expected Features=nil, got %#v", d.Features)
+	}
+}
+
+func TestClearX86OnlyDomainFeaturesForArchAmd64(t *testing.T) {
+	d := newDomainDef()
+	orig := d.Features
+	d.OS.Type.Arch = "x86_64"
+	clearX86OnlyDomainFeaturesForArch(&d)
+	if d.Features != orig {
+		t.Fatal("x86_64: Features should be unchanged")
+	}
+}
+
 func TestSetCoreOSIgnition(t *testing.T) {
 	testCases := []struct {
 		ignKey       string


### PR DESCRIPTION
newDomainDef() always set x86-oriented features. On s390x, RHEL 9 + QEMU 9 with machine types like s390-ccw-virtio-rhel9.6.0 reject <acpi/> with virError 67 (machine type does not support ACPI), blocking worker Machine creation.

Clear the features block for s390 after resolving host arch and machine type in newDomainDefForConnection. Add unit tests (ClearX86Only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a domain configuration issue for s390 architecture guests by properly excluding x86-specific virtual machine features that were previously incorrectly applied to guest definitions.

* **Tests**
  * Added comprehensive unit tests to thoroughly validate that domain feature handling now works correctly across multiple different processor architectures, including both s390x and modern x86_64.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->